### PR TITLE
Fixed method for adding new member into database

### DIFF
--- a/PixivDBManager.py
+++ b/PixivDBManager.py
@@ -286,21 +286,12 @@ class PixivDBManager:
 ##########################################
 ## IV. CRUD Member Table                ##
 ##########################################
-    def insertNewMember(self):
+    def insertNewMember(self, member_id, member_name):
         try:
             c = self.conn.cursor()
-            member_id = 0
-            while True:
-                temp = raw_input('Member ID: ')
-                try:
-                    member_id = int(temp)
-                except:
-                    pass
-                if member_id > 0:
-                    break
-
             c.execute('''INSERT OR IGNORE INTO pixiv_master_member VALUES(?, ?, ?, datetime('now'), '1-1-1', -1, 0)''',
-                                  (member_id, str(member_id), r'N\A'))
+                                  (member_id, member_name, r'N\A'))
+            self.conn.commit()
         except:
             print 'Error at insertNewMember():',str(sys.exc_info())
             print 'failed'

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -356,7 +356,10 @@ def process_member(mode, member_id, user_dir='', page=1, end_page=0, bookmark=Fa
                                    __config__.retry, __config__.backupOldFile)
                 is_avatar_downloaded = True
 
-            __dbManager__.updateMemberName(member_id, artist.artistName)
+            if not __dbManager__.selectMemberByMemberId(member_id):
+                __dbManager__.insertNewMember(member_id, artist.artistName)
+            else:
+                __dbManager__.updateMemberName(member_id, artist.artistName)
 
             if not artist.haveImages:
                 PixivHelper.printAndLog('info', "No image found for: " + str(member_id))


### PR DESCRIPTION
I noticed that `pixiv_master_member` table in my database is empty so I checked the code and found that DB manager's method `insertNewMember` is never called. So I fixed it and added code for calling it.