### PR TITLE
Add files via upload

### DIFF
--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -42,6 +42,7 @@ class PixivConfig:
     # generic Settings
     filenameFormat = unicode('%artist% (%member_id%)' + os.sep + '%urlFilename% - %title%')
     filenameMangaFormat = unicode('%artist% (%member_id%)' + os.sep + '%urlFilename% - %title%')
+    filenameInfoFormat = unicode('%artist% (%member_id%)' + os.sep + '%urlFilename% - %title%')
     rootDirectory = unicode('.')
     overwrite = False
     useList = False
@@ -57,6 +58,7 @@ class PixivConfig:
     useSuppressTags = False
     tagsLimit = -1
     writeImageInfo = False
+    writeImageJSON = False
     dateDiff = 0
     backupOldFile = False
     writeUgoiraInfo = False
@@ -91,7 +93,7 @@ class PixivConfig:
     def loadConfig(self, path=None):
         ''' new settings must be added on the last'''
 
-        if path != None:
+        if path is not None:
             self.configFileLocation = path
         else:
             self.configFileLocation = script_path + os.sep + 'config.ini'
@@ -168,17 +170,17 @@ class PixivConfig:
                 haveError = True
 
             _useragent = config.get('Network','useragent')
-            if _useragent != None:
+            if _useragent is not None:
                 self.useragent = _useragent
 
             _filenameFormat = config.get('Settings','filenameformat')
             _filenameFormat = PixivHelper.toUnicode(_filenameFormat, encoding=sys.stdin.encoding)
-            if _filenameFormat != None:
+            if _filenameFormat is not None:
                 self.filenameFormat = _filenameFormat
 
             _filenameMangaFormat = config.get('Settings','filenamemangaformat')
             _filenameMangaFormat = PixivHelper.toUnicode(_filenameMangaFormat, encoding=sys.stdin.encoding)
-            if _filenameMangaFormat != None:
+            if _filenameMangaFormat is not None:
                 ## check if the filename format have page identifier if not using %urlFilename%
                 if _filenameMangaFormat.find('%urlFilename%') == -1:
                     if _filenameMangaFormat.find('%page_index%') == -1 and _filenameMangaFormat.find('%page_number%') == -1:
@@ -187,6 +189,11 @@ class PixivConfig:
                         print "_filenameMangaFormat =", _filenameMangaFormat
                         haveError = True
                 self.filenameMangaFormat = _filenameMangaFormat
+                
+            _filenameInfoFormat = config.get('Settings','filenameinfoformat')
+            _filenameInfoFormat = PixivHelper.toUnicode(_filenameInfoFormat, encoding=sys.stdin.encoding)
+            if _filenameInfoFormat is not None:
+                self.filenameInfoFormat = _filenameInfoFormat
 
             try:
                 self.debugHttp = config.getboolean('Debug','debughttp')
@@ -319,6 +326,13 @@ class PixivConfig:
             except ValueError:
                 self.writeImageInfo = False
                 print "writeImageInfo = False"
+                haveError = True
+
+            try:
+                self.writeImageJSON = config.getboolean('Settings','writeImageJSON')
+            except ValueError:
+                self.writeImageJSON = False
+                print "writeImageJSON = False"
                 haveError = True
 
             try:
@@ -524,6 +538,7 @@ class PixivConfig:
         config.add_section('Settings')
         config.set('Settings', 'filenameFormat', self.filenameFormat)
         config.set('Settings', 'filenameMangaFormat', self.filenameMangaFormat)
+        config.set('Settings', 'filenameInfoFormat', self.filenameInfoFormat)
         config.set('Settings', 'avatarNameFormat', self.avatarNameFormat)
         config.set('Settings', 'downloadListDirectory', self.downloadListDirectory)
         config.set('Settings', 'useList', self.useList)
@@ -541,6 +556,7 @@ class PixivConfig:
         config.set('Settings', 'useSuppressTags', self.useSuppressTags)
         config.set('Settings', 'tagsLimit', self.tagsLimit)
         config.set('Settings', 'writeImageInfo', self.writeImageInfo)
+        config.set('Settings', 'writeImageJSON', self.writeImageJSON)
         config.set('Settings', 'dateDiff', self.dateDiff)
         config.set('Settings', 'backupOldFile', self.backupOldFile)
         config.set('Settings', 'writeUgoiraInfo', self.writeUgoiraInfo)
@@ -567,7 +583,7 @@ class PixivConfig:
         config.set('Pixiv', 'R18Mode', self.r18mode)
         config.set('Pixiv', 'DateFormat', self.dateFormat)
 
-        if path != None:
+        if path is not None:
             configlocation = path
         else:
             configlocation = 'config.ini'
@@ -625,6 +641,7 @@ class PixivConfig:
         print ' [Settings]'
         print ' - filename_format       =', self.filenameFormat
         print ' - filename_manga_format =', self.filenameMangaFormat
+        print ' - filename_info_format  =', self.filenameInfoFormat
         print ' - avatarNameFormat =', self.avatarNameFormat
         print ' - downloadListDirectory =', self.downloadListDirectory
         print ' - overwrite        =', self.overwrite
@@ -642,6 +659,7 @@ class PixivConfig:
         print ' - useSuppressTags  =', self.useSuppressTags
         print ' - tagsLimit        =', self.tagsLimit
         print ' - writeImageInfo   =', self.writeImageInfo
+        print ' - writeImageJSON   =', self.writeImageJSON
         print ' - dateDiff         =', self.dateDiff
         print ' - backupOldFile    =', self.backupOldFile
         print ' - writeUgoiraInfo  =', self.writeUgoiraInfo

--- a/PixivModel.py
+++ b/PixivModel.py
@@ -359,8 +359,12 @@ class PixivImage:
             elif len(tempCaption.text.strip()) == 0:
                 continue
             else:
-                self.imageCaption = tempCaption.text
-                # break
+                self.imageCaption = ''
+                for line in tempCaption.contents:
+                    if str(line)=='<br />':
+                        self.imageCaption += ('\n')
+                    else:
+                        self.imageCaption += (unicode(line))
 
         # stats
         view_count = page.find(attrs={'class': 'view-count'})
@@ -581,27 +585,54 @@ class PixivImage:
             PixivHelper.GetLogger().exception(
                 "Error when saving image info: " + filename + ", file is saved to: " + str(self.imageId) + ".txt")
 
-        info.write("ArtistID   = " + str(self.artist.artistId) + "\r\n")
-        info.write("ArtistName = " + self.artist.artistName + "\r\n")
-        info.write("ImageID    = " + str(self.imageId) + "\r\n")
-        info.write("Title      = " + self.imageTitle + "\r\n")
-        info.write("Caption    = " + self.imageCaption + "\r\n")
-        info.write("Tags       = " + ", ".join(self.imageTags) + "\r\n")
-        info.write("Image Mode = " + self.imageMode + "\r\n")
-        info.write("Pages      = " + str(self.imageCount) + "\r\n")
-        info.write("Date       = " + self.worksDate + "\r\n")
-        info.write("Resolution = " + self.worksResolution + "\r\n")
-        info.write("Tools      = " + self.worksTools + "\r\n")
-        info.write("BookmarkCount= " + str(self.bookmark_count) + "\r\n")
+        info.write("ArtistID      = " + str(self.artist.artistId) + "\r\n")
+        info.write("ArtistName    = " + self.artist.artistName + "\r\n")
+        info.write("ImageID       = " + str(self.imageId) + "\r\n")
+        info.write("Title         = " + self.imageTitle + "\r\n")
+        info.write("Caption       = " + self.imageCaption + "\r\n")
+        info.write("Tags          = " + ", ".join(self.imageTags) + "\r\n")
+        info.write("Image Mode    = " + self.imageMode + "\r\n")
+        info.write("Pages         = " + str(self.imageCount) + "\r\n")
+        info.write("Date          = " + self.worksDate + "\r\n")
+        info.write("Resolution    = " + self.worksResolution + "\r\n")
+        info.write("Tools         = " + self.worksTools + "\r\n")
+        info.write("BookmarkCount = " + str(self.bookmark_count) + "\r\n")
         info.write(
-            "Link       = http://www.pixiv.net/member_illust.php?mode=medium&illust_id=" + str(self.imageId) + "\r\n")
-        info.write("Ugoira Data= " + str(self.ugoira_data) + "\r\n")
+            "Link          = http://www.pixiv.net/member_illust.php?mode=medium&illust_id=" + str(self.imageId) + "\r\n")
+        info.write("Ugoira Data   = " + str(self.ugoira_data) + "\r\n")
         if len(self.descriptionUrlList) > 0:
-            info.write("Urls       =\r\n")
+            info.write("Urls          =\r\n")
             for link in self.descriptionUrlList:
                 info.write(" - " + link + "\r\n")
         info.close()
-
+        
+    def WriteJSON(self, filename):
+        info = None
+        try:
+            info = codecs.open(filename, 'w', encoding='utf-8')
+        except IOError:
+            info = codecs.open(str(self.imageId) + ".txt", 'w', encoding='utf-8')
+            PixivHelper.GetLogger().exception("Error when saving image info: " + filename + ", file is saved to: " + str(self.imageId) + ".txt")
+        info.write("{" + "\r\n")
+        info.write("\t" + json.dumps("Artist ID") + ": " + json.dumps(self.artist.artistId, ensure_ascii=False) + "," + "\r\n")
+        info.write("\t" + json.dumps("Artist Name") + ": " + json.dumps(self.artist.artistName, ensure_ascii=False) + "," + "\r\n")
+        info.write("\t" + json.dumps("Image ID") + ": " + json.dumps(self.imageId, ensure_ascii=False) + "," + "\r\n")
+        info.write("\t" + json.dumps("Title") + ": " + json.dumps(self.imageTitle, ensure_ascii=False) + "," + "\r\n")
+        info.write("\t" + json.dumps("Caption") + ": " + json.dumps(self.imageCaption, ensure_ascii=False) + "," + "\r\n")
+        info.write("\t" + json.dumps("Tags") + ": " + json.dumps(self.imageTags, ensure_ascii=False) + "," + "\r\n")
+        info.write("\t" + json.dumps("Image Mode") + ": " + json.dumps(self.imageMode, ensure_ascii=False) + "," + "\r\n")
+        info.write("\t" + json.dumps("Pages") + ": " + json.dumps(self.imageCount, ensure_ascii=False) + "," + "\r\n")
+        info.write("\t" + json.dumps("Date") + ": " + json.dumps(self.worksDate, ensure_ascii=False) + "," + "\r\n")
+        info.write("\t" + json.dumps("Resolution") + ": " + json.dumps(self.worksResolution, ensure_ascii=False) + "," + "\r\n")
+        info.write("\t" + json.dumps("Tools") + ": " + json.dumps(self.worksTools, ensure_ascii=False) + "," + "\r\n")
+        info.write("\t" + json.dumps("BookmarkCount") + ": " + json.dumps(self.bookmark_count, ensure_ascii=False) + "," + "\r\n")
+        info.write("\t" + json.dumps("Link") + ": " + json.dumps("http://www.pixiv.net/member_illust.php?mode=medium&illust_id=" + str(self.imageId), ensure_ascii=False) + "," + "\r\n")
+        info.write("\t" + json.dumps("Ugoira Data") + ": " + json.dumps(self.ugoira_data, ensure_ascii=False) + "\r\n")
+        if len(self.descriptionUrlList) > 0:
+            info.write("\t" + json.dumps("Urls") + ": " + json.dumps(self.descriptionUrlList, ensure_ascii=False) + "," + "\r\n")
+        info.write("}")
+        info.close()
+        
     def WriteUgoiraData(self, filename):
         info = None
         try:

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -644,6 +644,11 @@ def process_image(mode, artist=None, image_id=None, user_dir='', bookmark=False,
                 if image.imageMode == 'manga':
                     print "Page Count :", image.imageCount
 
+            if user_dir == '':  # Yavos: use config-options
+                target_dir = __config__.rootDirectory
+            else:  # Yavos: use filename from list
+                target_dir = user_dir
+
             result = PixivConstant.PIXIVUTIL_OK
             mangaFiles = dict()
             page = 0
@@ -657,14 +662,7 @@ def process_image(mode, artist=None, image_id=None, user_dir='', bookmark=False,
                     if image.imageMode == 'manga':
                         filename_format = __config__.filenameMangaFormat
 
-                    if user_dir == '':  # Yavos: use config-options
-                        target_dir = __config__.rootDirectory
-                    else:  # Yavos: use filename from list
-                        target_dir = user_dir
-
-                    filename = PixivHelper.makeFilename(filename_format, image, tagsSeparator=__config__.tagsSeparator,
-                                                        tagsLimit=__config__.tagsLimit, fileUrl=url, bookmark=bookmark,
-                                                        searchTags=search_tags)
+                    filename = PixivHelper.makeFilename(filename_format, image, tagsSeparator=__config__.tagsSeparator, tagsLimit=__config__.tagsLimit, fileUrl=url, bookmark=bookmark, searchTags=search_tags)
                     filename = PixivHelper.sanitizeFilename(filename, target_dir)
 
                     if image.imageMode == 'manga' and __config__.createMangaDir:
@@ -696,8 +694,19 @@ def process_image(mode, artist=None, image_id=None, user_dir='', bookmark=False,
                         __log__.exception('Error when download_image(): ' + str(img))
                     print ''
 
-            if __config__.writeImageInfo:
-                image.WriteInfo(filename + ".txt")
+            if __config__.writeImageInfo or __config__.writeImageJSON:
+                filename_info_format = __config__.filenameInfoFormat
+                info_filename = PixivHelper.makeFilename(filename_info_format, image, tagsSeparator=__config__.tagsSeparator,
+                                                    tagsLimit=__config__.tagsLimit, fileUrl=url, appendExtension=False, bookmark=bookmark,
+                                                    searchTags=search_tags)
+                info_filename = PixivHelper.sanitizeFilename(info_filename, target_dir)
+                # trim _pXXX
+                info_filename = re.sub('_p?\d+$', '', info_filename)
+                if __config__.writeImageInfo:
+                    image.WriteInfo(info_filename + ".txt")
+                if __config__.writeImageJSON:
+                    image.WriteJSON(info_filename + ".json")
+            
             if image.imageMode == 'ugoira_view':
                 if __config__.writeUgoiraInfo:
                     image.WriteUgoiraData(filename + ".js")


### PR DESCRIPTION
Added PixivImage.WriteJSON and altered other code to make it work.

1) In PixivConfig.py, added the filenameInfoFormat and writeImageJSON properties to the PixivConfig class.
2) In PixivModel.py, added a PixivImage.WriteJSON method and changed method PixivImage.ParseInfo to save newlines.
3) In PixivUtil2.py, added the call to PixivImage.WriteJSON and supporting logic to process_image(). Also moved the "target_dir" determination outside of the image.imageUrls for loop so WriteJSON could use it.

Most other changes were minor things like changing "!= None" to "is not None", and aligning the spacing in the PixivImage.WriteInfo.

The only thing that I'm aware of that changes the behavior of your code (outside of the WriteJSON addition) is the change to PixivImage.ParseInfo, which replaces <br />s with \n newlines instead of BeautifulSoup's .text ignoring that whitespace.
