### PR TITLE
Added Documentation to prevent non windows users from being confused about setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ Images/*
 testapp*/*
 .idea/*
 *.bak
+*.pyo
+pixivutil.log*

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,30 @@
 # -*- coding: UTF-8 -*-
 
 from distutils.core import setup
+
+import os
+
+isWindows = os.name is 'nt'
+
+if not isWindows:
+	print "____________________________"
+	print "          Notice            "
+	print "----------------------------"
+	print "Setup.py is used to generate executable under Windows systems\n"
+	print "For non windows systems please run:\n\tpip install -r requirements.txt\n"
+	print "Note: PixivUtil2 is not yet compatible with Python 3. If Python 3 is your default"
+	print "interpreter you will need to use a specific version of pip e.g.:\n"
+	print "\tpip-2.7 install -r requirements.txt\n"
+	print "After installing requirements run with command:\n"
+	print "\tpython PixivUtil2.py\n"
+	print "or if you need to specify python 2.x:\n"
+	print "\tpython2 PixivUtil2.py\n"
+	exit(-1)
+
+
 import py2exe
+
+
 
 setup(
     console = [


### PR DESCRIPTION
I've added some internal instructions so users confused about the setup py will stop opening issues for non windows systems.  I have tested the dependency installation and it works as described.

While I was in there I also told the repo to ignore log files and python objects.