### PR TITLE
SocksiPy 1.2 seems to be a wrong version number

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ imageio>=2.1.2
 mechanize>=0.3.3
 numpy>=1.12.1
 Pillow>=4.3.0
-socksipy-branch>=1.2
+socksipy-branch>=1.01
 win_unicode_console>=0.5


### PR DESCRIPTION
I don't know if there has a version 1.02. but surely 1.2 is not exist
I follow the url in the readme and it is just version 1.00.
I delete the version number in the requirments.txt and pip install the 1.01 for me.
this pull request just remind you to correct the version number. so you can just delete it. thanks