### PR TITLE
use python3 print format

### DIFF
--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -128,7 +128,7 @@ class PixivBrowser(mechanize.Browser):
                     for t in range(1, self._config.retryWait):
                         print t,
                         time.sleep(1)
-                    print ''
+                    print('')
                     retry_count = retry_count + 1
                 else:
                     raise PixivException("Failed to get page: " + ex.message, errorCode=PixivException.SERVER_ERROR)
@@ -255,13 +255,13 @@ class PixivBrowser(mechanize.Browser):
 
     def detectWhiteCube(self, page, url):
         if url.find("pixiv.net/whitecube") > 0:
-            print "*******************************************"
-            print "* Pixiv whitecube UI mode.                *"
-            print "* Some feature might not working properly *"
-            print "*******************************************"
+            print("*******************************************")
+            print("* Pixiv whitecube UI mode.                *")
+            print("* Some feature might not working properly *")
+            print("*******************************************")
             js_init = self._getInitConfig(page)
             self._whitecubeToken = js_init["pixiv.context.token"]
-            print "whitecube token:", self._whitecubeToken
+            print("whitecube token:", self._whitecubeToken)
             self._isWhitecube = True
 
     def parseLoginError(self, res):
@@ -544,7 +544,7 @@ def test():
 
     if success:
         def testSearchTags():
-            print "test search tags"
+            print("test search tags")
             tags = "VOCALOID"
             p = 1
             wild_card = True
@@ -566,75 +566,75 @@ def test():
             assert(len(resultS.itemList) > 0)
 
         def testImage():
-            print "test image mode"
-            print ">>"
+            print("test image mode")
+            print(">>")
             (result, page) = b.getImagePage(60040975)
-            print result.PrintInfo()
+            print(result.PrintInfo())
             assert(len(result.imageTitle) > 0)
-            print result.artist.PrintInfo()
+            print(result.artist.PrintInfo())
             assert(len(result.artist.artistToken) > 0)
             assert(not("R-18" in result.imageTags))
             assert(result.worksTools.find("CLIP STUDIO PAINT") > -1)
 
-            print ">>"
+            print(">>")
             (result2, page2) = b.getImagePage(59628358)
-            print result2.PrintInfo()
+            print(result2.PrintInfo())
             assert(len(result2.imageTitle) > 0)
-            print result2.artist.PrintInfo()
+            print(result2.artist.PrintInfo())
             assert(len(result2.artist.artistToken) > 0)
             assert("R-18" in result2.imageTags)
 
-            print ">> ugoira"
+            print(">> ugoira")
             (result3, page3) = b.getImagePage(60070169)
-            print result3.PrintInfo()
+            print(result3.PrintInfo())
             assert(len(result3.imageTitle) > 0)
-            print result3.artist.PrintInfo()
-            print result3.ugoira_data
+            print(result3.artist.PrintInfo())
+            print(result3.ugoira_data)
             assert(len(result3.artist.artistToken) > 0)
             assert(result3.imageMode == 'ugoira_view')
 
         def testMember():
-            print "Test member mode"
-            print ">>"
+            print("Test member mode")
+            print(">>")
             (result3, page3) = b.getMemberPage(1227869, page=1, bookmark=False, tags=None)
-            print result3.PrintInfo()
+            print(result3.PrintInfo())
             assert(len(result3.artistToken) > 0)
             assert(len(result3.imageList) > 0)
-            print ">>"
+            print(">>")
             (result4, page4) = b.getMemberPage(1227869, page=2, bookmark=False, tags=None)
-            print result4.PrintInfo()
+            print(result4.PrintInfo())
             assert(len(result4.artistToken) > 0)
             assert(len(result4.imageList) > 0)
-            print ">>"
+            print(">>")
             (result5, page5) = b.getMemberPage(4894, page=1, bookmark=False, tags=None)
-            print result5.PrintInfo()
+            print(result5.PrintInfo())
             assert(len(result5.artistToken) > 0)
             assert(len(result5.imageList) > 0)
-            print ">>"
+            print(">>")
             (result6, page6) = b.getMemberPage(4894, page=3, bookmark=False, tags=None)
-            print result6.PrintInfo()
+            print(result6.PrintInfo())
             assert(len(result6.artistToken) > 0)
             assert(len(result6.imageList) > 0)
 
         def testMemberBookmark():
-            print "Test member bookmarks mode"
-            print ">>"
+            print("Test member bookmarks mode")
+            print(">>")
             (result5, page5) = b.getMemberPage(1227869, page=1, bookmark=True, tags=None)
-            print result5.PrintInfo()
+            print(result5.PrintInfo())
             assert(len(result5.artistToken) > 0)
             assert(len(result5.imageList) > 0)
-            print ">>"
+            print(">>")
             (result6, page6) = b.getMemberPage(1227869, page=2, bookmark=True, tags=None)
-            print result6.PrintInfo()
+            print(result6.PrintInfo())
             assert(len(result6.artistToken) > 0)
             assert(len(result6.imageList) > 0)
-            print ">>"
+            print(">>")
             (result6, page6) = b.getMemberPage(1227869, page=10, bookmark=True, tags=None)
             if result6 is not None:
-                print result6.PrintInfo()
+                print(result6.PrintInfo())
             (result6, page6) = b.getMemberPage(1227869, page=12, bookmark=True, tags=None)
             if result6 is not None:
-                print result6.PrintInfo()
+                print(result6.PrintInfo())
                 assert(len(result6.artistToken) > 0)
                 assert(len(result6.imageList) == 0)
 
@@ -644,9 +644,9 @@ def test():
         # testMemberBookmark()
 
     else:
-        print "Invalid username or password"
+        print("Invalid username or password")
 
 
 if __name__ == '__main__':
     test()
-    print "done"
+    print("done")

--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -108,7 +108,7 @@ class PixivConfig:
         else:
             self.configFileLocation = script_path + os.sep + 'config.ini'
 
-        print 'Reading', self.configFileLocation, '...'
+        print('Reading', self.configFileLocation, '...')
         haveError = False
         config = ConfigParser.RawConfigParser()
         try:
@@ -132,28 +132,28 @@ class PixivConfig:
             try:
                 self.processFromDb = config.getboolean('Settings', 'processfromdb')
             except ValueError:
-                print "processFromDb = True"
+                print("processFromDb = True")
                 self.processFromDb = True
                 haveError = True
 
             try:
                 self.dayLastUpdated = config.getint('Settings', 'daylastupdated')
             except ValueError:
-                print "dayLastUpdated = 7"
+                print("dayLastUpdated = 7")
                 self.dayLastUpdated = 7
                 haveError = True
 
             try:
                 self.dateDiff = config.getint('Settings', 'datediff')
             except ValueError:
-                print "dateDiff = 0"
+                print("dateDiff = 0")
                 self.dateDiff = 0
                 haveError = True
 
             try:
                 self.proxyAddress = config.get('Network', 'proxyaddress')
             except ValueError:
-                print "proxyAddress = ''"
+                print("proxyAddress = ''")
                 self.proxyAddress = ''
                 haveError = True
             self.proxy = {'http': self.proxyAddress, 'https': self.proxyAddress}
@@ -161,21 +161,21 @@ class PixivConfig:
             try:
                 self.useProxy = config.getboolean('Network', 'useproxy')
             except ValueError:
-                print "useProxy = False"
+                print("useProxy = False")
                 self.useProxy = False
                 haveError = True
 
             try:
                 self.useList = config.getboolean('Settings', 'uselist')
             except ValueError:
-                print "useList = False"
+                print("useList = False")
                 self.useList = False
                 haveError = True
 
             try:
                 self.r18mode = config.getboolean('Pixiv', 'r18mode')
             except ValueError:
-                print "r18mode = False"
+                print("r18mode = False")
                 self.r18mode = False
                 haveError = True
 
@@ -194,9 +194,9 @@ class PixivConfig:
                 # check if the filename format have page identifier if not using %urlFilename%
                 if _filenameMangaFormat.find('%urlFilename%') == -1:
                     if _filenameMangaFormat.find('%page_index%') == -1 and _filenameMangaFormat.find('%page_number%') == -1:
-                        print 'No page identifier, appending %page_index% to the filename manga format.'
+                        print('No page identifier, appending %page_index% to the filename manga format.')
                         _filenameMangaFormat = _filenameMangaFormat + unicode(' %page_index%')
-                        print "_filenameMangaFormat =", _filenameMangaFormat
+                        print("_filenameMangaFormat =", _filenameMangaFormat)
                         haveError = True
                 self.filenameMangaFormat = _filenameMangaFormat
 
@@ -209,48 +209,48 @@ class PixivConfig:
                 self.debugHttp = config.getboolean('Debug', 'debughttp')
             except ValueError:
                 self.debugHttp = False
-                print "debugHttp = False"
+                print("debugHttp = False")
                 haveError = True
 
             try:
                 self.useRobots = config.getboolean('Network', 'userobots')
             except ValueError:
                 self.useRobots = False
-                print "useRobots = False"
+                print("useRobots = False")
                 haveError = True
 
             try:
                 self.overwrite = config.getboolean('Settings', 'overwrite')
             except ValueError:
-                print "overwrite = False"
+                print("overwrite = False")
                 self.overwrite = False
                 haveError = True
 
             try:
                 self.createMangaDir = config.getboolean('Settings', 'createMangaDir')
             except ValueError:
-                print "createMangaDir = False"
+                print("createMangaDir = False")
                 self.createMangaDir = False
                 haveError = True
 
             try:
                 self.timeout = config.getint('Network', 'timeout')
             except ValueError:
-                print "timeout = 60"
+                print("timeout = 60")
                 self.timeout = 60
                 haveError = True
 
             try:
                 self.retry = config.getint('Network', 'retry')
             except ValueError:
-                print "retry = 3"
+                print("retry = 3")
                 self.retry = 3
                 haveError = True
 
             try:
                 self.retryWait = config.getint('Network', 'retrywait')
             except ValueError:
-                print "retryWait = 5"
+                print("retryWait = 5")
                 self.retryWait = 5
                 haveError = True
 
@@ -258,90 +258,90 @@ class PixivConfig:
                 self.numberOfPage = config.getint('Pixiv', 'numberofpage')
             except ValueError:
                 self.numberOfPage = 0
-                print "numberOfPage = 0"
+                print("numberOfPage = 0")
                 haveError = True
 
             try:
                 self.createDownloadLists = config.getboolean('IrfanView', 'createDownloadLists')
             except ValueError:
                 self.createDownloadLists = False
-                print "createDownloadLists = False"
+                print("createDownloadLists = False")
                 haveError = True
 
             try:
                 self.startIrfanView = config.getboolean('IrfanView', 'startIrfanView')
             except ValueError:
                 self.startIrfanView = False
-                print "startIrfanView = False"
+                print("startIrfanView = False")
                 haveError = True
 
             try:
                 self.startIrfanSlide = config.getboolean('IrfanView', 'startIrfanSlide')
             except ValueError:
                 self.startIrfanSlide = False
-                print "startIrfanSlide = False"
+                print("startIrfanSlide = False")
                 haveError = True
 
             try:
                 self.alwaysCheckFileSize = config.getboolean('Settings', 'alwaysCheckFileSize')
             except ValueError:
                 self.alwaysCheckFileSize = False
-                print "alwaysCheckFileSize = False"
+                print("alwaysCheckFileSize = False")
                 haveError = True
 
             try:
                 self.downloadAvatar = config.getboolean('Settings', 'downloadAvatar')
             except ValueError:
                 self.downloadAvatar = False
-                print "downloadAvatar = False"
+                print("downloadAvatar = False")
                 haveError = True
 
             try:
                 self.checkUpdatedLimit = config.getint('Settings', 'checkUpdatedLimit')
             except ValueError:
                 self.checkUpdatedLimit = 0
-                print "checkUpdatedLimit = 0"
+                print("checkUpdatedLimit = 0")
                 haveError = True
 
             try:
                 self.useTagsAsDir = config.getboolean('Settings', 'useTagsAsDir')
             except ValueError:
                 self.useTagsAsDir = False
-                print "useTagsAsDir = False"
+                print("useTagsAsDir = False")
                 haveError = True
 
             try:
                 self.useBlacklistTags = config.getboolean('Settings', 'useBlacklistTags')
             except ValueError:
                 self.useBlacklistTags = False
-                print "useBlacklistTags = False"
+                print("useBlacklistTags = False")
                 haveError = True
 
             try:
                 self.useSuppressTags = config.getboolean('Settings', 'useSuppressTags')
             except ValueError:
                 self.useSuppressTags = False
-                print "useSuppressTags = False"
+                print("useSuppressTags = False")
                 haveError = True
 
             try:
                 self.tagsLimit = config.getint('Settings', 'tagsLimit')
             except ValueError:
                 self.tagsLimit = -1
-                print "tagsLimit = -1"
+                print("tagsLimit = -1")
                 haveError = True
 
             try:
                 self.writeImageInfo = config.getboolean('Settings', 'writeImageInfo')
             except ValueError:
                 self.writeImageInfo = False
-                print "writeImageInfo = False"
+                print("writeImageInfo = False")
                 haveError = True
 
             try:
                 self.keepSignedIn = config.getint('Authentication', 'keepSignedIn')
             except ValueError:
-                print "keepSignedIn = 0"
+                print("keepSignedIn = 0")
                 self.keepSignedIn = 0
                 haveError = True
 
@@ -349,7 +349,7 @@ class PixivConfig:
                 self.backupOldFile = config.getboolean('Settings', 'backupOldFile')
             except ValueError:
                 self.backupOldFile = False
-                print "backupOldFile = False"
+                print("backupOldFile = False")
                 haveError = True
 
             try:
@@ -357,28 +357,28 @@ class PixivConfig:
                 if self.logLevel not in ['CRITICAL', 'ERROR', 'WARN', 'WARNING', 'INFO', 'DEBUG', 'NOTSET']:
                     raise ValueError("Value not in list: " + self.logLevel)
             except ValueError:
-                print "logLevel = DEBUG"
+                print("logLevel = DEBUG")
                 self.logLevel = 'DEBUG'
                 haveError = True
 
             try:
                 self.enableDump = config.getboolean('Debug', 'enableDump')
             except ValueError:
-                print "enableDump = True"
+                print("enableDump = True")
                 self.enableDump = True
                 haveError = True
 
             try:
                 self.skipDumpFilter = config.get('Debug', 'skipDumpFilter')
             except ValueError:
-                print "skipDumpFilter = ''"
+                print("skipDumpFilter = ''")
                 self.skipDumpFilter = ''
                 haveError = True
 
             try:
                 self.dumpMediumPage = config.getboolean('Debug', 'dumpMediumPage')
             except ValueError:
-                print "dumpMediumPage = False"
+                print("dumpMediumPage = False")
                 self.dumpMediumPage = False
                 haveError = True
 
@@ -386,90 +386,90 @@ class PixivConfig:
                 self.writeUgoiraInfo = config.getboolean('Settings', 'writeUgoiraInfo')
             except ValueError:
                 self.writeUgoiraInfo = False
-                print "writeUgoiraInfo = False"
+                print("writeUgoiraInfo = False")
                 haveError = True
 
             try:
                 self.createUgoira = config.getboolean('Settings', 'createUgoira')
             except ValueError:
                 self.createUgoira = False
-                print "createUgoira = False"
+                print("createUgoira = False")
                 haveError = True
 
             try:
                 self.deleteZipFile = config.getboolean('Settings', 'deleteZipFile')
             except ValueError:
                 self.deleteZipFile = False
-                print "deleteZipFile = False"
+                print("deleteZipFile = False")
                 haveError = True
 
             try:
                 self.enableInfiniteLoop = config.getboolean('Settings', 'enableInfiniteLoop')
             except ValueError:
                 self.enableInfiniteLoop = False
-                print "enableInfiniteLoop = False"
+                print("enableInfiniteLoop = False")
                 haveError = True
 
             try:
                 self.dumpTagSearchPage = config.getboolean('Debug', 'dumpTagSearchPage')
             except ValueError:
                 self.dumpTagSearchPage = False
-                print "dumpTagSearchPage = False"
+                print("dumpTagSearchPage = False")
                 haveError = True
 
             try:
                 self.dateFormat = config.get('Pixiv', 'dateFormat')
             except ValueError:
-                print "dateFormat = ''"
+                print("dateFormat = ''")
                 self.dateFormat = ''
                 haveError = True
 
             try:
                 self.verifyImage = config.getboolean('Settings', 'verifyImage')
             except ValueError:
-                print "verifyImage = False"
+                print("verifyImage = False")
                 self.verifyImage = False
                 haveError = True
 
             try:
                 self.writeUrlInDescription = config.getboolean('Settings', 'writeUrlInDescription')
             except ValueError:
-                print "writeUrlInDescription = False"
+                print("writeUrlInDescription = False")
                 self.writeUrlInDescription = False
                 haveError = True
 
             try:
                 self.urlBlacklistRegex = config.get('Settings', 'urlBlacklistRegex')
             except ValueError:
-                print "urlBlacklistRegex = "
+                print("urlBlacklistRegex = ")
                 self.urlBlacklistRegex = ""
                 haveError = True
 
             try:
                 self.urlDumpFilename = config.get('Settings', 'urlDumpFilename')
             except ValueError:
-                print "urlDumpFilename = url_list_%Y%m%d"
+                print("urlDumpFilename = url_list_%Y%m%d")
                 self.urlDumpFilename = "url_list_%Y%m%d"
                 haveError = True
 
             try:
                 self.dbPath = config.get('Settings', 'dbPath')
             except ValueError:
-                print "dbPath = ''"
+                print("dbPath = ''")
                 self.dbPath = ''
                 haveError = True
 
             try:
                 self.createGif = config.getboolean('Settings', 'createGif')
             except ValueError:
-                print "createGif = False"
+                print("createGif = False")
                 self.createGif = False
                 haveError = True
 
             try:
                 self.useBlacklistMembers = config.getboolean('Settings', 'useBlacklistMembers')
             except ValueError:
-                print "useBlacklistMembers = False"
+                print("useBlacklistMembers = False")
                 self.useBlacklistMembers = False
                 haveError = True
 
@@ -477,14 +477,14 @@ class PixivConfig:
                 self.avatarNameFormat = config.get('Settings', 'avatarNameFormat')
                 self.avatarNameFormat = PixivHelper.toUnicode(self.avatarNameFormat, encoding=sys.stdin.encoding)
             except ValueError:
-                print "avatarNameFormat = "
+                print("avatarNameFormat = ")
                 self.avatarNameFormat = ""
                 haveError = True
 
             try:
                 self.createApng = config.getboolean('Settings', 'createApng')
             except ValueError:
-                print "createApng = False"
+                print("createApng = False")
                 self.createApng = False
                 haveError = True
 
@@ -492,68 +492,68 @@ class PixivConfig:
                 self.writeImageJSON = config.getboolean('Settings', 'writeImageJSON')
             except ValueError:
                 self.writeImageJSON = False
-                print "writeImageJSON = False"
+                print("writeImageJSON = False")
                 haveError = True
 
             try:
                 self.downloadDelay = config.getint('Network', 'downloadDelay')
             except ValueError:
                 self.downloadDelay = 2
-                print "downloadDelay = 2"
+                print("downloadDelay = 2")
                 haveError = True
 
             try:
                 self.deleteUgoira = config.getboolean('Settings', 'deleteUgoira')
             except ValueError:
-                print "deleteUgoira = False"
+                print("deleteUgoira = False")
                 self.deleteUgoira = False
                 haveError = True
 
             try:
                 self.createWebm = config.getboolean('Settings', 'createWebm')
             except ValueError:
-                print "createWebm = False"
+                print("createWebm = False")
                 self.createWebm = False
                 haveError = True
 
             try:
                 self.ffmpeg = config.get('FFmpeg', 'ffmpeg')
             except ValueError:
-                print "ffmpeg = 'ffmpeg'"
+                print("ffmpeg = 'ffmpeg'")
                 self.ffmpeg = 'ffmpeg'
                 haveError = True
 
             try:
                 self.ffmpegCodec = config.get('FFmpeg', 'ffmpegCodec')
             except ValueError:
-                print "ffmpegCodec = 'libvpx-vp9'"
+                print("ffmpegCodec = 'libvpx-vp9'")
                 self.ffmpegCodec = 'libvpx-vp9'
                 haveError = True
 
             try:
                 self.ffmpegParam = config.get('FFmpeg', 'ffmpegParam')
             except ValueError:
-                print "ffmpegParam = '-lossless 1'"
+                print("ffmpegParam = '-lossless 1'")
                 self.ffmpegParam = '-lossless 1'
                 haveError = True
 
             try:
                 self.setLastModified = config.getboolean('Settings', 'setLastModified')
             except ValueError:
-                print "setLastModified = True"
+                print("setLastModified = True")
                 self.setLastModified = True
                 haveError = True
 
         except BaseException:
-            print 'Error at loadConfig():', sys.exc_info()
+            print('Error at loadConfig():', sys.exc_info())
             self.__logger.exception('Error at loadConfig()')
             haveError = True
 
         if haveError:
-            print 'Some configuration have invalid value, replacing with the default value.'
+            print('Some configuration have invalid value, replacing with the default value.')
             self.writeConfig(error=True)
 
-        print 'done.'
+        print('done.')
 
     # -UI01B------write config
     def writeConfig(self, error=False, path=None):
@@ -653,97 +653,98 @@ class PixivConfig:
             if os.path.exists(configlocation):
                 if error:
                     backupName = configlocation + '.error-' + str(int(time.time()))
-                    print "Backing up old config (error exist!) to " + backupName
+                    print("Backing up old config (error exist!) to " +
+                            backupName)
                     shutil.move(configlocation, backupName)
                 else:
-                    print "Backing up old config to config.ini.bak"
+                    print("Backing up old config to config.ini.bak")
                     shutil.move(configlocation, configlocation + '.bak')
             os.rename(configlocation + '.tmp', configlocation)
         except BaseException:
             self.__logger.exception('Error at writeConfig()')
             raise
 
-        print 'done.'
+        print('done.')
 
     def printConfig(self):
-        print 'Configuration: '
-        print ' [Authentication]'
-        print ' - username     =', self.username
-        print ' - password     = ', self.password
-        print ' - cookie       = ', self.cookie
-        print ' - keepSignedIn = ', self.keepSignedIn
+        print('Configuration: ')
+        print(' [Authentication]')
+        print(' - username     =', self.username)
+        print(' - password     = ', self.password)
+        print(' - cookie       = ', self.cookie)
+        print(' - keepSignedIn = ', self.keepSignedIn)
 
-        print ' [Network]'
-        print ' - useproxy         =', self.useProxy
-        print ' - proxyaddress     =', self.proxyAddress
-        print ' - useragent        =', self.useragent
-        print ' - use_robots       =', self.useRobots
-        print ' - timeout          =', self.timeout
-        print ' - retry            =', self.retry
-        print ' - retryWait        =', self.retryWait
-        print ' - downloadDelay      =', self.downloadDelay
+        print(' [Network]')
+        print(' - useproxy         =', self.useProxy)
+        print(' - proxyaddress     =', self.proxyAddress)
+        print(' - useragent        =', self.useragent)
+        print(' - use_robots       =', self.useRobots)
+        print(' - timeout          =', self.timeout)
+        print(' - retry            =', self.retry)
+        print(' - retryWait        =', self.retryWait)
+        print(' - downloadDelay      =', self.downloadDelay)
 
-        print ' [Debug]'
-        print ' - logLevel         =', self.logLevel
-        print ' - enableDump       =', self.enableDump
-        print ' - skipDumpFilter   =', self.skipDumpFilter
-        print ' - dumpMediumPage   =', self.dumpMediumPage
-        print ' - dumpTagSearchPage=', self.dumpTagSearchPage
-        print ' - debug_http       =', self.debugHttp
+        print(' [Debug]')
+        print(' - logLevel         =', self.logLevel)
+        print(' - enableDump       =', self.enableDump)
+        print(' - skipDumpFilter   =', self.skipDumpFilter)
+        print(' - dumpMediumPage   =', self.dumpMediumPage)
+        print(' - dumpTagSearchPage=', self.dumpTagSearchPage)
+        print(' - debug_http       =', self.debugHttp)
 
-        print ' [IrfanView]'
-        print ' - IrfanViewPath    =', self.IrfanViewPath
-        print ' - startIrfanView   =', self.startIrfanView
-        print ' - startIrfanSlide  =', self.startIrfanSlide
-        print ' - createDownloadLists   =', self.createDownloadLists
+        print(' [IrfanView]')
+        print(' - IrfanViewPath    =', self.IrfanViewPath)
+        print(' - startIrfanView   =', self.startIrfanView)
+        print(' - startIrfanSlide  =', self.startIrfanSlide)
+        print(' - createDownloadLists   =', self.createDownloadLists)
 
-        print ' [Settings]'
-        print ' - filename_format       =', self.filenameFormat
-        print ' - filename_manga_format =', self.filenameMangaFormat
-        print ' - filename_info_format  =', self.filenameInfoFormat
-        print ' - avatarNameFormat =', self.avatarNameFormat
-        print ' - downloadListDirectory =', self.downloadListDirectory
-        print ' - overwrite        =', self.overwrite
-        print ' - useList          =', self.useList
-        print ' - processFromDb    =', self.processFromDb
-        print ' - tagsSeparator    =', self.tagsSeparator
-        print ' - dayLastUpdated   =', self.dayLastUpdated
-        print ' - rootDirectory    =', self.rootDirectory
-        print ' - alwaysCheckFileSize   =', self.alwaysCheckFileSize
-        print ' - checkUpdatedLimit     =', self.checkUpdatedLimit
-        print ' - downloadAvatar   =', self.downloadAvatar
-        print ' - createMangaDir   =', self.createMangaDir
-        print ' - useTagsAsDir     =', self.useTagsAsDir
-        print ' - useBlacklistTags =', self.useBlacklistTags
-        print ' - useSuppressTags  =', self.useSuppressTags
-        print ' - tagsLimit        =', self.tagsLimit
-        print ' - writeImageInfo   =', self.writeImageInfo
-        print ' - writeImageJSON   =', self.writeImageJSON
-        print ' - dateDiff         =', self.dateDiff
-        print ' - backupOldFile    =', self.backupOldFile
-        print ' - writeUgoiraInfo  =', self.writeUgoiraInfo
-        print ' - createUgoira     =', self.createUgoira
-        print ' - deleteZipFile    =', self.deleteZipFile
-        print ' - enableInfiniteLoop    =', self.enableInfiniteLoop
-        print ' - verifyImage      =', self.verifyImage
-        print ' - writeUrlInDescription =', self.writeUrlInDescription
-        print ' - urlBlacklistRegex =', self.urlBlacklistRegex
-        print ' - urlDumpFilename  =', self.urlDumpFilename
-        print ' - dbPath           =', self.dbPath
-        print ' - createGif        =', self.createGif
-        print ' - useBlacklistMembers  =', self.useBlacklistMembers
-        print ' - createApng       =', self.createApng
-        print ' - deleteUgoira     =', self.deleteUgoira
-        print ' - createWebm       =', self.createWebm
-        print ' - setLastModified  =', self.setLastModified
+        print(' [Settings]')
+        print(' - filename_format       =', self.filenameFormat)
+        print(' - filename_manga_format =', self.filenameMangaFormat)
+        print(' - filename_info_format  =', self.filenameInfoFormat)
+        print(' - avatarNameFormat =', self.avatarNameFormat)
+        print(' - downloadListDirectory =', self.downloadListDirectory)
+        print(' - overwrite        =', self.overwrite)
+        print(' - useList          =', self.useList)
+        print(' - processFromDb    =', self.processFromDb)
+        print(' - tagsSeparator    =', self.tagsSeparator)
+        print(' - dayLastUpdated   =', self.dayLastUpdated)
+        print(' - rootDirectory    =', self.rootDirectory)
+        print(' - alwaysCheckFileSize   =', self.alwaysCheckFileSize)
+        print(' - checkUpdatedLimit     =', self.checkUpdatedLimit)
+        print(' - downloadAvatar   =', self.downloadAvatar)
+        print(' - createMangaDir   =', self.createMangaDir)
+        print(' - useTagsAsDir     =', self.useTagsAsDir)
+        print(' - useBlacklistTags =', self.useBlacklistTags)
+        print(' - useSuppressTags  =', self.useSuppressTags)
+        print(' - tagsLimit        =', self.tagsLimit)
+        print(' - writeImageInfo   =', self.writeImageInfo)
+        print(' - writeImageJSON   =', self.writeImageJSON)
+        print(' - dateDiff         =', self.dateDiff)
+        print(' - backupOldFile    =', self.backupOldFile)
+        print(' - writeUgoiraInfo  =', self.writeUgoiraInfo)
+        print(' - createUgoira     =', self.createUgoira)
+        print(' - deleteZipFile    =', self.deleteZipFile)
+        print(' - enableInfiniteLoop    =', self.enableInfiniteLoop)
+        print(' - verifyImage      =', self.verifyImage)
+        print(' - writeUrlInDescription =', self.writeUrlInDescription)
+        print(' - urlBlacklistRegex =', self.urlBlacklistRegex)
+        print(' - urlDumpFilename  =', self.urlDumpFilename)
+        print(' - dbPath           =', self.dbPath)
+        print(' - createGif        =', self.createGif)
+        print(' - useBlacklistMembers  =', self.useBlacklistMembers)
+        print(' - createApng       =', self.createApng)
+        print(' - deleteUgoira     =', self.deleteUgoira)
+        print(' - createWebm       =', self.createWebm)
+        print(' - setLastModified  =', self.setLastModified)
 
-        print ' [Pixiv]'
-        print ' - numberOfPage =', self.numberOfPage
-        print ' - R18Mode      =', self.r18mode
-        print ' - DateFormat   =', self.dateFormat
+        print(' [Pixiv]')
+        print(' - numberOfPage =', self.numberOfPage)
+        print(' - R18Mode      =', self.r18mode)
+        print(' - DateFormat   =', self.dateFormat)
 
-        print ' [FFmpeg]'
-        print ' - ffmpeg       =', self.ffmpeg
-        print ' - ffmpegCodec  =', self.ffmpegCodec
-        print ' - ffmpegParam  =', self.ffmpegParam
-        print ''
+        print(' [FFmpeg]')
+        print(' - ffmpeg       =', self.ffmpeg)
+        print(' - ffmpegCodec  =', self.ffmpegCodec)
+        print(' - ffmpegParam  =', self.ffmpegParam)
+        print('')

--- a/PixivDBManager.py
+++ b/PixivDBManager.py
@@ -87,10 +87,10 @@ class PixivDBManager:
                             )''')
             self.conn.commit()
 
-            print 'done.'
+            print('done.')
         except BaseException:
-            print 'Error at createDatabase():', str(sys.exc_info())
-            print 'failed.'
+            print('Error at createDatabase():', str(sys.exc_info()))
+            print('failed.')
             raise
         finally:
             c.close()
@@ -104,25 +104,25 @@ class PixivDBManager:
             c.execute('''DROP IF EXISTS TABLE pixiv_master_image''')
             self.conn.commit()
         except BaseException:
-            print 'Error at dropDatabase():', str(sys.exc_info())
-            print 'failed.'
+            print('Error at dropDatabase():', str(sys.exc_info()))
+            print('failed.')
             raise
         finally:
             c.close()
-        print 'done.'
+        print('done.')
 
     def compactDatabase(self):
-        print 'Compacting Database, this might take a while...'
+        print('Compacting Database, this might take a while...')
         try:
             c = self.conn.cursor()
             c.execute('''VACUUM''')
             self.conn.commit()
         except BaseException:
-            print 'Error at compactDatabase():', str(sys.exc_info())
+            print('Error at compactDatabase():', str(sys.exc_info()))
             raise
         finally:
             c.close()
-        print 'done.'
+        print('done.')
 
 ##########################################
 ## II. Export/Import DB                 ##
@@ -142,12 +142,12 @@ class PixivDBManager:
                           (item.path, item.memberId))
             self.conn.commit()
         except BaseException:
-            print 'Error at importList():', str(sys.exc_info())
-            print 'failed'
+            print('Error at importList():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
-        print 'done.'
+        print('done.')
         return 0
 
     def exportList(self, filename, include_artist_token=True):
@@ -175,14 +175,14 @@ class PixivDBManager:
                 writer.write('\r\n')
             writer.write('###END-OF-FILE###')
         except BaseException:
-            print 'Error at exportList():', str(sys.exc_info())
-            print 'failed'
+            print('Error at exportList():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             if writer is not None:
                 writer.close()
             c.close()
-        print 'done.'
+        print('done.')
 
     def exportDetailedList(self, filename):
         print 'Exporting detailed list...',
@@ -204,24 +204,26 @@ class PixivDBManager:
             writer.write('###END-OF-FILE###')
             writer.close()
         except BaseException:
-            print 'Error at exportDetailedList(): ' + str(sys.exc_info())
-            print 'failed'
+            print('Error at exportDetailedList(): ' + str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
-        print 'done.'
+        print('done.')
 
 ##########################################
 ## III. Print DB                        ##
 ##########################################
     def printMemberList(self, isDeleted=False):
-        print 'Printing member list:'
+        print('Printing member list:')
         try:
             c = self.conn.cursor()
             c.execute('''SELECT * FROM pixiv_master_member
                          WHERE is_deleted = ?
                             ORDER BY member_id''', (int(isDeleted), ))
-            print '%10s %25s %25s %20s %20s %10s %s' % ('member_id', 'name', 'save_folder', 'created_date', 'last_update_date', 'last_image', 'is_deleted')
+            print('%10s %25s %25s %20s %20s %10s %s' % ('member_id', 'name',
+                'save_folder', 'created_date', 'last_update_date', 'last_image',
+                'is_deleted'))
             i = 0
             for row in c:
                 PixivHelper.safePrint('%10d %#25s %#25s %20s %20s %10d %5s' % (row[0], unicode(row[1]).strip(), row[2], row[3], row[4], row[5], row[6]))
@@ -231,55 +233,55 @@ class PixivDBManager:
                     if select == 'n':
                         break
                     else:
-                        print 'member_id\tname\tsave_folder\tcreated_date\tlast_update_date\tlast_image'
+                        print('member_id\tname\tsave_folder\tcreated_date\tlast_update_date\tlast_image')
                         i = 0
         except BaseException:
-            print 'Error at printList():', str(sys.exc_info())
-            print 'failed'
+            print('Error at printList():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
-        print 'done.'
+        print('done.')
 
     def printImageList(self):
-        print 'Printing image list:'
+        print('Printing image list:')
         try:
             c = self.conn.cursor()
             c.execute(''' SELECT COUNT(*) FROM pixiv_master_image''')
             result = c.fetchall()
             if result[0][0] > 10000:
-                print 'Row count is more than 10000 (actual row count:', str(result[0][0]), ')'
-                print 'It may take a while to retrieve the data.'
+                print('Row count is more than 10000 (actual row count:', str(result[0][0]), ')')
+                print('It may take a while to retrieve the data.')
                 answer = raw_input('Continue [y/n]')
                 if answer == 'y':
                     c.execute('''SELECT * FROM pixiv_master_image
                                     ORDER BY member_id''')
-                    print ''
+                    print('')
                     for row in c:
                         for string in row:
                             print '   ',
                             PixivHelper.safePrint(unicode(string), False)
-                        print ''
+                        print('')
                 else:
                     return
             # Yavos: it seems you forgot something ;P
             else:
                 c.execute('''SELECT * FROM pixiv_master_image
                                     ORDER BY member_id''')
-                print ''
+                print('')
                 for row in c:
                     for string in row:
                         print '   ',
                         PixivHelper.safePrint(unicode(string), False)   # would it make more sense to set output to file?
-                    print ''
+                    print('')
             # Yavos: end of change
         except BaseException:
-            print 'Error at printImageList():', str(sys.exc_info())
-            print 'failed'
+            print('Error at printImageList():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
-        print 'done.'
+        print('done.')
 
 ##########################################
 ## IV. CRUD Member Table                ##
@@ -300,8 +302,8 @@ class PixivDBManager:
             c.execute('''INSERT OR IGNORE INTO pixiv_master_member VALUES(?, ?, ?, datetime('now'), '1-1-1', -1, 0)''',
                                   (member_id, str(member_id), r'N\A'))
         except BaseException:
-            print 'Error at insertNewMember():', str(sys.exc_info())
-            print 'failed'
+            print('Error at insertNewMember():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -318,8 +320,8 @@ class PixivDBManager:
                 l.append(item)
 
         except BaseException:
-            print 'Error at selectAllMember():', str(sys.exc_info())
-            print 'failed'
+            print('Error at selectAllMember():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -344,8 +346,8 @@ class PixivDBManager:
                 l.append(item)
 
         except BaseException:
-            print 'Error at selectMembersByLastDownloadDate():', str(sys.exc_info())
-            print 'failed'
+            print('Error at selectMembersByLastDownloadDate():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -358,8 +360,8 @@ class PixivDBManager:
             c.execute('''SELECT * FROM pixiv_master_member WHERE member_id = ? ''', (member_id, ))
             return c.fetchone()
         except BaseException:
-            print 'Error at selectMemberByMemberId():', str(sys.exc_info())
-            print 'failed'
+            print('Error at selectMemberByMemberId():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -374,8 +376,8 @@ class PixivDBManager:
             else:
                 return PixivListItem(int(member_id), '')
         except BaseException:
-            print 'Error at selectMemberByMemberId():', str(sys.exc_info())
-            print 'failed'
+            print('Error at selectMemberByMemberId():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -387,7 +389,7 @@ class PixivDBManager:
             for string in row:
                 print '   ',
                 PixivHelper.safePrint(unicode(string), False)
-            print '\n'
+            print('\n')
 
     def updateMemberName(self, memberId, memberName):
         try:
@@ -398,8 +400,8 @@ class PixivDBManager:
                             ''', (memberName, memberId))
             self.conn.commit()
         except BaseException:
-            print 'Error at updateMemberId():', str(sys.exc_info())
-            print 'failed'
+            print('Error at updateMemberId():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -413,8 +415,8 @@ class PixivDBManager:
                             ''', (saveFolder, memberId))
             self.conn.commit()
         except BaseException:
-            print 'Error at updateSaveFolder():', str(sys.exc_info())
-            print 'failed'
+            print('Error at updateSaveFolder():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -428,8 +430,8 @@ class PixivDBManager:
                             (imageId, memberId))
             self.conn.commit()
         except BaseException:
-            print 'Error at updateMemberId():', str(sys.exc_info())
-            print 'failed'
+            print('Error at updateMemberId():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -442,8 +444,8 @@ class PixivDBManager:
                             (memberId, ))
             self.conn.commit()
         except BaseException:
-            print 'Error at deleteMemberByMemberId():', str(sys.exc_info())
-            print 'failed'
+            print('Error at deleteMemberByMemberId():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -459,8 +461,8 @@ class PixivDBManager:
                             (memberId, ))
             self.conn.commit()
         except BaseException:
-            print 'Error at deleteCascadeMemberByMemberId():', str(sys.exc_info())
-            print 'failed'
+            print('Error at deleteCascadeMemberByMemberId():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -474,8 +476,8 @@ class PixivDBManager:
                             (memberId,))
             self.conn.commit()
         except BaseException:
-            print 'Error at setIsDeletedMemberId():', str(sys.exc_info())
-            print 'failed'
+            print('Error at setIsDeletedMemberId():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -492,8 +494,8 @@ class PixivDBManager:
                       (image_id, member_id, isManga))
             self.conn.commit()
         except BaseException:
-            print 'Error at insertImage():', str(sys.exc_info())
-            print 'failed'
+            print('Error at insertImage():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -505,8 +507,8 @@ class PixivDBManager:
                               (imageId, page, filename))
             self.conn.commit()
         except BaseException:
-            print 'Error at insertMangaImage():', str(sys.exc_info())
-            print 'failed'
+            print('Error at insertMangaImage():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -518,8 +520,8 @@ class PixivDBManager:
                               (ImageId, memberId))
             self.conn.commit()
         except BaseException:
-            print 'Error at insertImage():', str(sys.exc_info())
-            print 'failed'
+            print('Error at insertImage():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -530,8 +532,8 @@ class PixivDBManager:
             c.execute('''SELECT * FROM pixiv_master_image WHERE member_id = ? ''', (member_id,))
             return c.fetchall()
         except BaseException:
-            print 'Error at selectImageByImageId():', str(sys.exc_info())
-            print 'failed'
+            print('Error at selectImageByImageId():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -542,8 +544,8 @@ class PixivDBManager:
             c.execute('''SELECT image_id FROM pixiv_master_image WHERE image_id = ? AND save_name != 'N/A' AND member_id = ?''', (image_id, member_id))
             return c.fetchone()
         except BaseException:
-            print 'Error at selectImageByImageId():', str(sys.exc_info())
-            print 'failed'
+            print('Error at selectImageByImageId():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -554,8 +556,8 @@ class PixivDBManager:
             c.execute('''SELECT * FROM pixiv_master_image WHERE image_id = ? AND save_name != 'N/A' ''', (image_id,))
             return c.fetchone()
         except BaseException:
-            print 'Error at selectImageByImageId():', str(sys.exc_info())
-            print 'failed'
+            print('Error at selectImageByImageId():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -566,8 +568,8 @@ class PixivDBManager:
             c.execute('''SELECT * FROM pixiv_manga_image WHERE image_id = ? AND page = ? ''', (imageId, page))
             return c.fetchone()
         except BaseException:
-            print 'Error at selectImageByImageIdAndPage():', str(sys.exc_info())
-            print 'failed'
+            print('Error at selectImageByImageIdAndPage():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -581,8 +583,8 @@ class PixivDBManager:
                         (title, filename, isManga, imageId))
             self.conn.commit()
         except BaseException:
-            print 'Error at updateImage():', str(sys.exc_info())
-            print 'failed'
+            print('Error at updateImage():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -595,19 +597,19 @@ class PixivDBManager:
                         (imageId, ))
             self.conn.commit()
         except BaseException:
-            print 'Error at deleteImage():', str(sys.exc_info())
-            print 'failed'
+            print('Error at deleteImage():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
 
     def cleanUp(self):
         try:
-            print "Start clean-up operation."
-            print "Selecting all images, this may take some times."
+            print("Start clean-up operation.")
+            print("Selecting all images, this may take some times.")
             c = self.conn.cursor()
             c.execute('''SELECT image_id, save_name from pixiv_master_image''')
-            print "Checking images."
+            print("Checking images.")
             for row in c:
                 # Issue 238
                 fileExists = False
@@ -628,8 +630,8 @@ class PixivDBManager:
                     self.deleteImage(row[0])
             self.conn.commit()
         except BaseException:
-            print 'Error at cleanUp():', str(sys.exc_info())
-            print 'failed'
+            print('Error at cleanUp():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -639,23 +641,23 @@ class PixivDBManager:
         PixivHelper.safePrint("Replacing " + oldPath + " to " + self.__config__.rootDirectory)
         cont = raw_input("continue[y/n]?") or 'n'
         if cont != "y":
-            print "Aborted"
+            print("Aborted")
             return
 
         try:
-            print "Start replace Root Path operation."
-            print "Updating images, this may take some times."
+            print("Start replace Root Path operation.")
+            print("Updating images, this may take some times.")
 
             c = self.conn.cursor()
             c.execute('''UPDATE pixiv_master_image
                          SET save_name = replace(save_name, ?, ?)
                          WHERE save_name like ?''', (oldPath, self.__config__.rootDirectory, oldPath + "%", ))
-            print "Updated image:", c.rowcount
-            print "Done"
+            print("Updated image:", c.rowcount)
+            print("Done")
 
         except BaseException:
-            print 'Error at replaceRootPath():', str(sys.exc_info())
-            print 'failed'
+            print('Error at replaceRootPath():', str(sys.exc_info()))
+            print('failed')
             raise
         finally:
             c.close()
@@ -673,25 +675,25 @@ class PixivDBManager:
 # if inputInt != None:
 # return inputInt
     def menu(self):
-        print 'Pixiv DB Manager Console'
-        print '1. Show all member'
-        print '2. Show all images'
-        print '3. Export list (member_id only)'
-        print '4. Export list (detailed)'
-        print '5. Show member by last downloaded date'
-        print '6. Show image by image_id'
-        print '7. Show member by member_id'
-        print '8. Show image by member_id'
-        print '9. Delete member by member_id'
-        print '10. Delete image by image_id'
-        print '11. Delete member and image (cascade deletion)'
-        print '12. Blacklist image by image_id'
-        print '13. Show all deleted member'
-        print '==============================================='
-        print 'c. Clean Up Database'
-        print 'p. Compact Database'
-        print 'r. Replace Root Path'
-        print 'x. Exit'
+        print('Pixiv DB Manager Console')
+        print('1. Show all member')
+        print('2. Show all images')
+        print('3. Export list (member_id only)')
+        print('4. Export list (detailed)')
+        print('5. Show member by last downloaded date')
+        print('6. Show image by image_id')
+        print('7. Show member by member_id')
+        print('8. Show image by member_id')
+        print('9. Delete member by member_id')
+        print('10. Delete image by image_id')
+        print('11. Delete member and image (cascade deletion)')
+        print('12. Blacklist image by image_id')
+        print('13. Show all deleted member')
+        print('===============================================')
+        print('c. Clean Up Database')
+        print('p. Compact Database')
+        print('r. Replace Root Path')
+        print('x. Exit')
         selection = raw_input('Select one?')
         return selection
 
@@ -722,7 +724,7 @@ class PixivDBManager:
                         for row in rows:
                             PixivHelper.safePrint("{0}\t\t{1}\n".format(row.memberId, row.path), False)
                     else:
-                        print 'Not Found!\n'
+                        print('Not Found!\n')
                 elif selection == '6':
                     image_id = raw_input('image_id? ')
                     row = self.selectImageByImageId(image_id)
@@ -730,9 +732,9 @@ class PixivDBManager:
                         for string in row:
                             print '	',
                             PixivHelper.safePrint(unicode(string), False)
-                        print '\n'
+                        print('\n')
                     else:
-                        print 'Not Found!\n'
+                        print('Not Found!\n')
                 elif selection == '7':
                     member_id = raw_input('member_id? ')
                     row = self.selectMemberByMemberId(member_id)
@@ -740,9 +742,9 @@ class PixivDBManager:
                         for string in row:
                             print '	',
                             PixivHelper.safePrint(unicode(string), False)
-                        print '\n'
+                        print('\n')
                     else:
-                        print 'Not Found!\n'
+                        print('Not Found!\n')
                 elif selection == '8':
                     member_id = raw_input('member_id? ')
                     rows = self.selectImageByMemberId(member_id)
@@ -751,9 +753,9 @@ class PixivDBManager:
                             for string in row:
                                 print '	',
                                 PixivHelper.safePrint(unicode(string), False)
-                            print '\n'
+                            print('\n')
                     else:
-                        print 'Not Found!\n'
+                        print('Not Found!\n')
                 elif selection == '9':
                     member_id = raw_input('member_id? ')
                     self.deleteMemberByMemberId(member_id)
@@ -777,9 +779,9 @@ class PixivDBManager:
                     self.replaceRootPath()
                 elif selection == 'x':
                     break
-            print 'end PixivDBManager.'
+            print('end PixivDBManager.')
         except BaseException:
-            print 'Error: ', sys.exc_info()
+            print('Error: ', sys.exc_info())
             self.main()
 
 

--- a/PixivHelper.py
+++ b/PixivHelper.py
@@ -249,7 +249,7 @@ def safePrint(msg, newline=True):
         except UnicodeError:
             print ('?' * len(msgToken)),
     if newline:
-        print ""
+        print("")
 
 
 def setConsoleTitle(title):
@@ -536,7 +536,7 @@ def printDelay(retryWait):
     for t in repeat:
         print t,
         time.sleep(1)
-    print ''
+    print('')
 
 
 def create_custom_request(url, config, referer='https://www.pixiv.net', head=False):
@@ -591,12 +591,12 @@ def downloadImage(url, filename, res, file_size, overwrite):
             # check if downloaded file is complete
             if file_size > 0 and curr == file_size:
                 total_time = (datetime.now() - start_time).total_seconds()
-                print u'\n Completed in {0}s ({1})'.format(total_time, speedInStr(file_size, total_time))
+                print(u'\n Completed in {0}s ({1})'.format(total_time, speedInStr(file_size, total_time)))
                 break
 
             elif curr == prev:  # no file size info
                 total_time = (datetime.now() - start_time).total_seconds()
-                print u'\n Completed in {0}s ({1})'.format(total_time, speedInStr(curr, total_time))
+                print(u'\n Completed in {0}s ({1})'.format(total_time, speedInStr(curr, total_time)))
                 break
 
             prev = curr
@@ -664,14 +664,14 @@ def generateSearchTagUrl(tags, page, title_caption, wild_card, oldest_first,
     else:
         if title_caption:
             url = 'https://www.pixiv.net/search.php?s_mode=s_tc&p=' + str(page) + '&word=' + tags + date_param
-            print u"Using Title Match (s_tc)"
+            print(u"Using Title Match (s_tc)")
         else:
             if wild_card:
                 url = 'https://www.pixiv.net/search.php?s_mode=s_tag&p=' + str(page) + '&word=' + tags + date_param
-                print u"Using Partial Match (s_tag)"
+                print(u"Using Partial Match (s_tag)")
             else:
                 url = 'https://www.pixiv.net/search.php?s_mode=s_tag_full&word=' + tags + '&p=' + str(page) + date_param
-                print u"Using Full Match (s_tag_full)"
+                print(u"Using Full Match (s_tag_full)")
 
     if r18mode:
         url = url + '&mode=r18'
@@ -816,7 +816,7 @@ def ugoira2webm(ugoira_file,
             chatter += buff
             if buff.endswith("\r"):
                 if chatter.find("frame=") > 0:
-                    print chatter.strip(), os.linesep,
+                    print(chatter.strip(), os.linesep,)
                 chatter = ""
             if len(buff) == 0:
                 break
@@ -829,7 +829,7 @@ def ugoira2webm(ugoira_file,
             os.remove(ugoira_file)
 
         if ret is not None:
-            print "done with status= {0}".format(ret)
+            print("done with status= {0}".format(ret))
 
     finally:
         shutil.rmtree(d)

--- a/PixivModel.py
+++ b/PixivModel.py
@@ -523,20 +523,20 @@ class PixivImage:
             expected_url = '/member_illust.php?mode=big&illust_id=' + str(self.imageId)
             try:
                 href = _br.fixUrl(expected_url)
-                print "Fetching big image page:", href
+                print("Fetching big image page:", href)
                 bigPage = _br.getPixivPage(url=href,
                                            referer="https://www.pixiv.net/member_illust.php?mode=medium&illust_id=" + str(self.imageId))
                 bigImg = bigPage.find('img')
                 imgUrl = bigImg["src"]
                 # http://i2.pixiv.net/img-original/img/2013/12/27/01/51/37/40538869_p7.jpg
-                print "Found: ", imgUrl
+                print("Found: ", imgUrl)
                 bigImg.decompose()
                 bigPage.decompose()
                 del bigImg
                 del bigPage
                 return imgUrl
             except Exception as ex:
-                print ex
+                print(ex)
 
         # new layout for big 20141216
         temp = page.find('img', attrs={'class': 'original-image'})
@@ -570,7 +570,7 @@ class PixivImage:
         twopage_format = page.find("html", attrs={'class': re.compile(r".*\b_book-viewer\b.*")})
         if twopage_format is not None and len(twopage_format) > 0:
             # new format
-            print "2-page manga viewer mode"
+            print("2-page manga viewer mode")
             return self.ParseMangaImagesScript(page)
         else:
             # standard format
@@ -627,8 +627,8 @@ class PixivImage:
                 del bigImg
                 del bigPage
             except Exception as ex:
-                print ex
-        print "\r{0:120}".format("Manga pages parsed.")
+                print(ex)
+        print("\r{0:120}".format("Manga pages parsed."))
 
         return urls
 
@@ -1079,7 +1079,7 @@ class PixivTags:
         PixivHelper.safePrint('haveImage  : {0}'.format(self.haveImage))
         PixivHelper.safePrint('urls  : {0}'.format(len(self.itemList)))
         for item in self.itemList:
-            print "\tImage Id: {0}\tFav Count:{1}".format(item.imageId, item.bookmarkCount)
+            print("\tImage Id: {0}\tFav Count:{1}".format(item.imageId, item.bookmarkCount))
         PixivHelper.safePrint('total : {0}'.format(self.availableImages))
         PixivHelper.safePrint('last? : {0}'.format(self.isLastPage))
 

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -101,7 +101,7 @@ __re_manga_page = re.compile(r'(\d+(_big)?_p\d+)')
 
 # issue #299
 def get_remote_filesize(url, referer):
-    print 'Getting remote filesize...'
+    print('Getting remote filesize...')
     # open with HEAD method, might be expensive
     req = PixivHelper.create_custom_request(url, __config__, referer, head=True)
     res = __br__.open_novisit(req)
@@ -111,7 +111,7 @@ def get_remote_filesize(url, referer):
     except KeyError:
         file_size = -1
         PixivHelper.print_and_log('info', "\tNo file size information!")
-    print "Remote filesize = {0} ({1} Bytes)".format(PixivHelper.sizeInStr(file_size), file_size)
+    print("Remote filesize = {0} ({1} Bytes)".format(PixivHelper.sizeInStr(file_size), file_size))
     return file_size
 
 
@@ -313,7 +313,7 @@ def download_image(url, filename, referer, overwrite, max_retry, backup_old_file
 
             if retry_count < max_retry:
                 retry_count = retry_count + 1
-                print "Retrying [{0}]...".format(retry_count)
+                print("Retrying [{0}]...".format(retry_count))
                 PixivHelper.printDelay(__config__.retryWait)
             else:
                 raise
@@ -331,7 +331,7 @@ def process_list(list_file_name=None, tags=None):
             if __config__.dayLastUpdated == 0:
                 result = __dbManager__.selectAllMember()
             else:
-                print 'Select only last', __config__.dayLastUpdated, 'days.'
+                print('Select only last', __config__.dayLastUpdated, 'days.')
                 result = __dbManager__.selectMembersByLastDownloadDate(__config__.dayLastUpdated)
         else:
             PixivHelper.print_and_log('info', 'Processing from list file: {0}'.format(list_file_name))
@@ -346,7 +346,7 @@ def process_list(list_file_name=None, tags=None):
                         result.remove(item)
                         break
 
-        print "Found " + str(len(result)) + " items."
+        print("Found " + str(len(result)) + " items.")
 
         for item in result:
             retry_count = 0
@@ -361,17 +361,17 @@ def process_list(list_file_name=None, tags=None):
                         PixivHelper.print_and_log('error', 'Giving up member_id: ' + str(item.memberId))
                         break
                     retry_count = retry_count + 1
-                    print 'Something wrong, retrying after 2 second (', retry_count, ')'
+                    print('Something wrong, retrying after 2 second (', retry_count, ')')
                     time.sleep(2)
 
             __br__.clear_history()
-            print 'done.'
+            print('done.')
     except KeyboardInterrupt:
         raise
     except Exception as ex:
         ERROR_CODE = getattr(ex, 'errorCode', -1)
-        print 'Error at process_list():', sys.exc_info()
-        print 'Failed'
+        print('Error at process_list():', sys.exc_info())
+        print('Failed')
         __log__.exception('Error at process_list(): ' + str(sys.exc_info()))
         raise
 
@@ -410,7 +410,7 @@ def process_member(member_id, user_dir='', page=1, end_page=0, bookmark=False, t
         image_id = -1
 
         while flag:
-            print 'Page ', page
+            print('Page ', page)
             set_console_title("MemberId: " + str(member_id) + " Page: " + str(page))
             # Try to get the member page
             while True:
@@ -446,8 +446,8 @@ def process_member(member_id, user_dir='', page=1, end_page=0, bookmark=False, t
                     __log__.exception('Error at processing Artist Info: ' + str(member_id))
 
             PixivHelper.safePrint('Member Name  : ' + artist.artistName)
-            print 'Member Avatar:', artist.artistAvatar
-            print 'Member Token :', artist.artistToken
+            print('Member Avatar:', artist.artistAvatar)
+            print('Member Token :', artist.artistToken)
 
             if artist.artistAvatar.find('no_profile') == -1 and not is_avatar_downloaded and __config__.downloadAvatar:
                 if user_dir == '':
@@ -471,15 +471,15 @@ def process_member(member_id, user_dir='', page=1, end_page=0, bookmark=False, t
 
             result = PixivConstant.PIXIVUTIL_NOT_OK
             for image_id in artist.imageList:
-                print '#' + str(no_of_images)
+                print('#' + str(no_of_images))
                 if not __config__.overwrite:
                     r = __dbManager__.selectImageByMemberIdAndImageId(member_id, image_id)
                     if r is not None and not __config__.alwaysCheckFileSize:
-                        print 'Already downloaded:', image_id
+                        print('Already downloaded:', image_id)
                         updated_limit_count = updated_limit_count + 1
                         if updated_limit_count > __config__.checkUpdatedLimit:
                             if __config__.checkUpdatedLimit != 0:
-                                print 'Skipping member:', member_id
+                                print('Skipping member:', member_id)
                                 __dbManager__.updateLastDownloadedImage(member_id, image_id)
 
                                 del list_page
@@ -518,7 +518,7 @@ def process_member(member_id, user_dir='', page=1, end_page=0, bookmark=False, t
                             PixivHelper.print_and_log('error', "Giving up image_id: " + str(image_id))
                             return
                         retry_count = retry_count + 1
-                        print "Stuff happened, trying again after 2 second (", retry_count, ")"
+                        print("Stuff happened, trying again after 2 second (", retry_count, ")")
                         exc_type, exc_value, exc_traceback = sys.exc_info()
                         traceback.print_exception(exc_type, exc_value, exc_traceback)
                         __log__.exception('Error at process_member(): ' + str(sys.exc_info()) + ' Member Id: ' + str(member_id))
@@ -542,22 +542,22 @@ def process_member(member_id, user_dir='', page=1, end_page=0, bookmark=False, t
                     break
 
             if artist.isLastPage:
-                print "Last Page"
+                print("Last Page")
                 flag = False
 
             page = page + 1
 
             # page limit checking
             if end_page > 0 and page > end_page:
-                print "Page limit reached (from endPage limit =" + str(end_page) + ")"
+                print("Page limit reached (from endPage limit =" + str(end_page) + ")")
                 flag = False
             else:
                 if np_is_valid:  # Yavos: overwriting config-data
                     if page > np and np > 0:
-                        print "Page limit reached (from command line =" + str(np) + ")"
+                        print("Page limit reached (from command line =" + str(np) + ")")
                         flag = False
                 elif page > __config__.numberOfPage and __config__.numberOfPage > 0:
-                    print "Page limit reached (from config =" + str(__config__.numberOfPage) + ")"
+                    print("Page limit reached (from config =" + str(__config__.numberOfPage) + ")")
                     flag = False
 
             del artist
@@ -570,7 +570,7 @@ def process_member(member_id, user_dir='', page=1, end_page=0, bookmark=False, t
             log_message = 'last image_id: ' + str(image_id)
         else:
             log_message = 'no images were found'
-        print 'Done.\n'
+        print('Done.\n')
         __log__.info('Member_id: ' + str(member_id) + ' complete, ' + log_message)
     except KeyboardInterrupt:
         raise
@@ -601,13 +601,13 @@ def process_image(artist=None, image_id=None, user_dir='', bookmark=False, searc
 
     try:
         filename = 'N/A'
-        print 'Processing Image Id:', image_id
+        print('Processing Image Id:', image_id)
 
         # check if already downloaded. images won't be downloaded twice - needed in process_image to catch any download
         r = __dbManager__.selectImageByImageId(image_id)
         if r is not None and not __config__.alwaysCheckFileSize:
             if not __config__.overwrite:
-                print 'Already downloaded:', image_id
+                print('Already downloaded:', image_id)
                 gc.collect()
                 return
 
@@ -673,12 +673,12 @@ def process_image(artist=None, image_id=None, user_dir='', bookmark=False, searc
         if download_image_flag:
             if artist is None:
                 PixivHelper.safePrint('Member Name  : ' + image.artist.artistName)
-                print 'Member Avatar:', image.artist.artistAvatar
-                print 'Member Token :', image.artist.artistToken
+                print('Member Avatar:', image.artist.artistAvatar)
+                print('Member Token :', image.artist.artistToken)
             PixivHelper.safePrint("Title: " + image.imageTitle)
             PixivHelper.safePrint("Tags : " + ', '.join(image.imageTags))
             PixivHelper.safePrint("Date : " + str(image.worksDateDateTime))
-            print "Mode :", image.imageMode
+            print("Mode :", image.imageMode)
 
             # get bookmark count
             if ("%bookmark_count%" in __config__.filenameFormat or "%image_response_count%" in __config__.filenameFormat) and image.bookmark_count == -1:
@@ -688,7 +688,7 @@ def process_image(artist=None, image_id=None, user_dir='', bookmark=False, searc
                 image.ParseBookmarkDetails(parse_bookmark_page)
                 parse_bookmark_page.decompose()
                 del parse_bookmark_page
-                print "Bookmark Count :", str(image.bookmark_count)
+                print("Bookmark Count :", str(image.bookmark_count))
                 __br__.back()
 
             if __config__.useSuppressTags:
@@ -720,7 +720,7 @@ def process_image(artist=None, image_id=None, user_dir='', bookmark=False, searc
                         return PixivConstant.PIXIVUTIL_NOT_OK
 
                 if image.imageMode == 'manga':
-                    print "Page Count :", image.imageCount
+                    print("Page Count :", image.imageCount)
 
             if user_dir == '':  # Yavos: use config-options
                 target_dir = __config__.rootDirectory
@@ -731,7 +731,7 @@ def process_image(artist=None, image_id=None, user_dir='', bookmark=False, searc
             manga_files = dict()
             page = 0
             for img in image.imageUrls:
-                print 'Image URL :', img
+                print('Image URL :', img)
                 url = os.path.basename(img)
                 split_url = url.split('.')
                 if split_url[0].startswith(str(image_id)):
@@ -770,7 +770,7 @@ def process_image(artist=None, image_id=None, user_dir='', bookmark=False, searc
                     except urllib2.URLError:
                         PixivHelper.print_and_log('error', 'Giving up url: ' + str(img))
                         __log__.exception('Error when download_image(): ' + str(img))
-                    print ''
+                    print('')
 
             if __config__.writeImageInfo or __config__.writeImageJSON:
                 filename_info_format = __config__.filenameInfoFormat
@@ -833,7 +833,7 @@ def process_image(artist=None, image_id=None, user_dir='', bookmark=False, searc
             del image
         gc.collect()
         # clearall()
-        print '\n'
+        print('\n')
         return result
     except KeyboardInterrupt:
         raise
@@ -863,7 +863,7 @@ def process_tags(tags, page=1, end_page=0, wild_card=True, title_caption=False,
         search_tags = PixivHelper.decode_tags(tags)
 
         if use_tags_as_dir:
-            print "Save to each directory using query tags."
+            print("Save to each directory using query tags.")
             __config__.rootDirectory += os.sep + PixivHelper.sanitizeFilename(search_tags)
 
         tags = PixivHelper.encode_tags(tags)
@@ -891,14 +891,14 @@ def process_tags(tags, page=1, end_page=0, wild_card=True, title_caption=False,
                                                   oldest_first,
                                                   page)
             if len(t.itemList) == 0:
-                print 'No more images'
+                print('No more images')
                 flag = False
             else:
                 for item in t.itemList:
                     last_image_id = item.imageId
-                    print 'Image #' + str(images)
-                    print 'Image Id:', str(item.imageId)
-                    print 'Bookmark Count:', str(item.bookmarkCount)
+                    print('Image #' + str(images))
+                    print('Image Id:', str(item.imageId))
+                    print('Bookmark Count:', str(item.bookmarkCount))
                     if bookmark_count is not None and bookmark_count > item.bookmarkCount:
                         PixivHelper.print_and_log('info', 'Skipping imageId= {0} because less than bookmark count limit ({1} > {2}).'.format(item.imageId, bookmark_count, item.bookmarkCount))
                         skipped_count = skipped_count + 1
@@ -930,7 +930,7 @@ def process_tags(tags, page=1, end_page=0, wild_card=True, title_caption=False,
                             result = PixivConstant.PIXIVUTIL_KEYBOARD_INTERRUPT
                             break
                         except httplib.BadStatusLine:
-                            print "Stuff happened, trying again after 2 second..."
+                            print("Stuff happened, trying again after 2 second...")
                             time.sleep(2)
 
                     images = images + 1
@@ -974,11 +974,11 @@ def process_tags(tags, page=1, end_page=0, wild_card=True, title_caption=False,
                     PixivHelper.print_and_log('info', "No more image in the list.")
                     flag = False
 
-        print 'done'
+        print('done')
     except KeyboardInterrupt:
         raise
     except BaseException:
-        print 'Error at process_tags():', sys.exc_info()
+        print('Error at process_tags():', sys.exc_info())
         __log__.exception('Error at process_tags(): ' + str(sys.exc_info()))
         try:
             if search_page is not None:
@@ -996,7 +996,7 @@ def process_tags_list(filename, page=1, end_page=0, wild_card=True,
     global ERROR_CODE
 
     try:
-        print "Reading:", filename
+        print("Reading:", filename)
         l = PixivTags.parseTagsList(filename)
         for tag in l:
             process_tags(tag, page=page, end_page=end_page, wild_card=wild_card,
@@ -1006,7 +1006,7 @@ def process_tags_list(filename, page=1, end_page=0, wild_card=True,
         raise
     except Exception as ex:
         ERROR_CODE = getattr(ex, 'errorCode', -1)
-        print 'Error at process_tags_list():', sys.exc_info()
+        print('Error at process_tags_list():', sys.exc_info())
         __log__.exception('Error at process_tags_list(): ' + str(sys.exc_info()))
         raise
 
@@ -1015,7 +1015,7 @@ def process_image_bookmark(hide='n', start_page=1, end_page=0, tag=''):
     global np_is_valid
     global np
     try:
-        print "Importing image bookmarks..."
+        print("Importing image bookmarks...")
         totalList = list()
         image_count = 1
 
@@ -1030,16 +1030,16 @@ def process_image_bookmark(hide='n', start_page=1, end_page=0, tag=''):
 
         PixivHelper.print_and_log('info', "Found " + str(len(totalList)) + " image(s).")
         for item in totalList:
-            print "Image #" + str(image_count)
+            print("Image #" + str(image_count))
             process_image(artist=None, image_id=item)
             image_count = image_count + 1
             wait()
 
-        print "Done.\n"
+        print("Done.\n")
     except KeyboardInterrupt:
         raise
     except BaseException:
-        print 'Error at process_image_bookmark():', sys.exc_info()
+        print('Error at process_image_bookmark():', sys.exc_info())
         __log__.exception('Error at process_image_bookmark(): ' + str(sys.exc_info()))
         raise
 
@@ -1050,7 +1050,7 @@ def get_image_bookmark(hide, start_page=1, end_page=0, tag=''):
     i = start_page
     while True:
         if end_page != 0 and i > end_page:
-            print "Page Limit reached: " + str(end_page)
+            print("Page Limit reached: " + str(end_page))
             break
 
         url = 'https://www.pixiv.net/bookmark.php?p=' + str(i)
@@ -1067,10 +1067,10 @@ def get_image_bookmark(hide, start_page=1, end_page=0, tag=''):
         l = PixivBookmark.parseImageBookmark(parse_page)
         total_list.extend(l)
         if len(l) == 0:
-            print "No more images."
+            print("No more images.")
             break
         else:
-            print " found " + str(len(l)) + " images."
+            print(" found " + str(len(l)) + " images.")
 
         i = i + 1
 
@@ -1086,7 +1086,7 @@ def get_bookmarks(hide, start_page=1, end_page=0, member_id=None):
     i = start_page
     while True:
         if end_page != 0 and i > end_page:
-            print 'Limit reached'
+            print('Limit reached')
             break
         PixivHelper.print_and_log('info', 'Exporting page ' + str(i))
         url = 'https://www.pixiv.net/bookmark.php?type=user&p=' + str(i)
@@ -1100,11 +1100,11 @@ def get_bookmarks(hide, start_page=1, end_page=0, member_id=None):
         parse_page = BeautifulSoup(page.read())
         l = PixivBookmark.parseBookmark(parse_page)
         if len(l) == 0:
-            print 'No more data'
+            print('No more data')
             break
         total_list.extend(l)
         i = i + 1
-        print str(len(l)), 'items'
+        print(str(len(l)), 'items')
     return total_list
 
 
@@ -1112,12 +1112,12 @@ def process_bookmark(hide='n', start_page=1, end_page=0):
     try:
         total_list = list()
         if hide != 'o':
-            print "Importing Bookmarks..."
+            print("Importing Bookmarks...")
             total_list.extend(get_bookmarks(False, start_page, end_page))
         if hide != 'n':
-            print "Importing Private Bookmarks..."
+            print("Importing Private Bookmarks...")
             total_list.extend(get_bookmarks(True, start_page, end_page))
-        print "Result: ", str(len(total_list)), "items."
+        print("Result: ", str(len(total_list)), "items.")
         i = 0
         for item in total_list:
             print("%d/%d\t%f %%" % (i, len(total_list), 100.0 * i / float(len(total_list))))
@@ -1127,7 +1127,7 @@ def process_bookmark(hide='n', start_page=1, end_page=0):
     except KeyboardInterrupt:
         raise
     except BaseException:
-        print 'Error at process_bookmark():', sys.exc_info()
+        print('Error at process_bookmark():', sys.exc_info())
         __log__.exception('Error at process_bookmark(): ' + str(sys.exc_info()))
         raise
 
@@ -1136,29 +1136,29 @@ def export_bookmark(filename, hide='n', start_page=1, end_page=0, member_id=None
     try:
         total_list = list()
         if hide != 'o':
-            print "Importing Bookmarks..."
+            print("Importing Bookmarks...")
             total_list.extend(get_bookmarks(False, start_page, end_page, member_id))
         if hide != 'n':
-            print "Importing Private Bookmarks..."
+            print("Importing Private Bookmarks...")
             total_list.extend(get_bookmarks(True, start_page, end_page, member_id))
-        print "Result: ", str(len(total_list)), "items."
+        print("Result: ", str(len(total_list)), "items.")
         PixivBookmark.exportList(total_list, filename)
     except KeyboardInterrupt:
         raise
     except BaseException:
-        print 'Error at export_bookmark():', sys.exc_info()
+        print('Error at export_bookmark():', sys.exc_info())
         __log__.exception('Error at export_bookmark(): ' + str(sys.exc_info()))
         raise
 
 
 def process_new_illust_from_bookmark(page_num=1, end_page_num=0):
     try:
-        print "Processing New Illust from bookmark"
+        print("Processing New Illust from bookmark")
         i = page_num
         image_count = 1
         flag = True
         while flag:
-            print "Page #" + str(i)
+            print("Page #" + str(i))
             url = 'https://www.pixiv.net/bookmark_new_illust.php?p=' + str(i)
             if __config__.r18mode:
                 url = 'https://www.pixiv.net/bookmark_new_illust_r18.php?p=' + str(i)
@@ -1168,11 +1168,11 @@ def process_new_illust_from_bookmark(page_num=1, end_page_num=0):
             parsed_page = BeautifulSoup(page.read())
             pb = PixivNewIllustBookmark(parsed_page)
             if not pb.haveImages:
-                print "No images!"
+                print("No images!")
                 break
 
             for image_id in pb.imageList:
-                print "Image #" + str(image_count)
+                print("Image #" + str(image_count))
                 result = process_image(artist=None, image_id=int(image_id))
                 image_count = image_count + 1
 
@@ -1189,25 +1189,25 @@ def process_new_illust_from_bookmark(page_num=1, end_page_num=0):
             # Non premium is only limited to 100 page
             # Premium user might be limited to 5000, refer to issue #112
             if (end_page_num != 0 and i > end_page_num) or i > 5000 or pb.isLastPage:
-                print "Limit or last page reached."
+                print("Limit or last page reached.")
                 flag = False
 
-        print "Done."
+        print("Done.")
     except KeyboardInterrupt:
         raise
     except BaseException:
-        print 'Error at process_new_illust_from_bookmark():', sys.exc_info()
+        print('Error at process_new_illust_from_bookmark():', sys.exc_info())
         __log__.exception('Error at process_new_illust_from_bookmark(): ' + str(sys.exc_info()))
         raise
 
 
 def process_from_group(group_id, limit=0, process_external=True):
     try:
-        print "Download by Group Id"
+        print("Download by Group Id")
         if limit != 0:
-            print "Limit: {0}".format(limit)
+            print("Limit: {0}".format(limit))
         if process_external:
-            print "Include External Image: {0}".format(process_external)
+            print("Include External Image: {0}".format(process_external))
 
         max_id = 0
         image_count = 0
@@ -1223,8 +1223,8 @@ def process_from_group(group_id, limit=0, process_external=True):
                     if image_count > limit and limit != 0:
                         flag = False
                         break
-                    print "Image #{0}".format(image_count)
-                    print "ImageId: {0}".format(image)
+                    print("Image #{0}".format(image_count))
+                    print("ImageId: {0}".format(image))
                     process_image(image_id=image)
                     image_count = image_count + 1
                     wait()
@@ -1234,11 +1234,11 @@ def process_from_group(group_id, limit=0, process_external=True):
                     if image_count > limit and limit != 0:
                         flag = False
                         break
-                    print "Image #{0}".format(image_count)
-                    print "Member Id   : {0}".format(image_data.artist.artistId)
+                    print("Image #{0}".format(image_count))
+                    print("Member Id   : {0}".format(image_data.artist.artistId))
                     PixivHelper.safePrint("Member Name  : " + image_data.artist.artistName)
-                    print "Member Token : {0}".format(image_data.artist.artistToken)
-                    print "Image Url   : {0}".format(image_data.imageUrls[0])
+                    print("Member Token : {0}".format(image_data.artist.artistToken))
+                    print("Image Url   : {0}".format(image_data.imageUrls[0]))
 
                     filename = PixivHelper.makeFilename(__config__.filenameFormat, imageInfo=image_data,
                                                         tagsSeparator=__config__.tagsSeparator,
@@ -1255,18 +1255,18 @@ def process_from_group(group_id, limit=0, process_external=True):
             if (group_data.imageList is None or len(group_data.imageList) == 0) and \
                (group_data.externalImageList is None or len(group_data.externalImageList) == 0):
                 flag = False
-            print ""
+            print("")
 
     except BaseException:
-        print 'Error at process_from_group():', sys.exc_info()
+        print('Error at process_from_group():', sys.exc_info())
         __log__.exception('Error at process_from_group(): ' + str(sys.exc_info()))
         raise
 
 
 def header():
-    print 'PixivDownloader2 version', PixivConstant.PIXIVUTIL_VERSION
-    print PixivConstant.PIXIVUTIL_LINK
-    print 'Donate at', PixivConstant.PIXIVUTIL_DONATE
+    print('PixivDownloader2 version', PixivConstant.PIXIVUTIL_VERSION)
+    print(PixivConstant.PIXIVUTIL_LINK)
+    print('Donate at', PixivConstant.PIXIVUTIL_DONATE)
 
 
 def get_start_and_end_number(start_only=False):
@@ -1277,7 +1277,7 @@ def get_start_and_end_number(start_only=False):
     try:
         page_num = int(page_num)
     except BaseException:
-        print "Invalid page number:", page_num
+        print("Invalid page number:", page_num)
         raise
 
     end_page_num = 0
@@ -1291,10 +1291,10 @@ def get_start_and_end_number(start_only=False):
         try:
             end_page_num = int(end_page_num)
             if page_num > end_page_num and end_page_num != 0:
-                print "page_num is bigger than end_page_num, assuming as page count."
+                print("page_num is bigger than end_page_num, assuming as page count.")
                 end_page_num = page_num + end_page_num
         except BaseException:
-            print "Invalid end page number:", end_page_num
+            print("Invalid end page number:", end_page_num)
             raise
 
     return page_num, end_page_num
@@ -1307,9 +1307,9 @@ def get_start_and_end_number_from_args(args, offset=0, start_only=False):
     if len(args) > 0 + offset:
         try:
             page_num = int(args[0 + offset])
-            print "Start Page =", str(page_num)
+            print("Start Page =", str(page_num))
         except BaseException:
-            print "Invalid page number:", args[0 + offset]
+            print("Invalid page number:", args[0 + offset])
             raise
 
     end_page_num = 0
@@ -1323,11 +1323,11 @@ def get_start_and_end_number_from_args(args, offset=0, start_only=False):
             try:
                 end_page_num = int(args[1 + offset])
                 if page_num > end_page_num and end_page_num != 0:
-                    print "page_num is bigger than end_page_num, assuming as page count."
+                    print("page_num is bigger than end_page_num, assuming as page count.")
                     end_page_num = page_num + end_page_num
-                print "End Page =", str(end_page_num)
+                print("End Page =", str(end_page_num))
             except BaseException:
-                print "Invalid end page number:", args[1 + offset]
+                print("Invalid end page number:", args[1 + offset])
                 raise
     return page_num, end_page_num
 
@@ -1347,7 +1347,7 @@ def get_start_and_end_date():
                 start_date = check_date_time(start_date)
             break
         except Exception as e:
-            print str(e)
+            print(str(e))
 
     while True:
         try:
@@ -1356,7 +1356,7 @@ def get_start_and_end_date():
                 end_date = check_date_time(end_date)
             break
         except Exception as e:
-            print str(e)
+            print(str(e))
 
     return start_date, end_date
 
@@ -1364,25 +1364,25 @@ def get_start_and_end_date():
 def menu():
     set_console_title()
     header()
-    print '1. Download by member_id'
-    print '2. Download by image_id'
-    print '3. Download by tags'
-    print '4. Download from list'
-    print '5. Download from bookmarked artists (bookmark.php?type=user)'
-    print '6. Download from bookmarked images (bookmark.php)'
-    print '7. Download from tags list'
-    print '8. Download new illust from bookmarked members (bookmark_new_illust.php)'
-    print '9. Download by Title/Caption'
-    print '10. Download by Tag and Member Id'
-    print '11. Download Member Bookmark'
-    print '12. Download by Group Id'
-    print '------------------------'
-    print 'd. Manage database'
-    print 'e. Export online bookmark'
-    print 'm. Export online user bookmark'
-    print 'r. Reload config.ini'
-    print 'p. Print config.ini'
-    print 'x. Exit'
+    print('1. Download by member_id')
+    print('2. Download by image_id')
+    print('3. Download by tags')
+    print('4. Download from list')
+    print('5. Download from bookmarked artists (bookmark.php?type=user)')
+    print('6. Download from bookmarked images (bookmark.php)')
+    print('7. Download from tags list')
+    print('8. Download new illust from bookmarked members (bookmark_new_illust.php)')
+    print('9. Download by Title/Caption')
+    print('10. Download by Tag and Member Id')
+    print('11. Download Member Bookmark')
+    print('12. Download by Group Id')
+    print('------------------------')
+    print('d. Manage database')
+    print('e. Export online bookmark')
+    print('m. Export online user bookmark')
+    print('r. Reload config.ini')
+    print('p. Print config.ini')
+    print('x. Exit')
 
     return raw_input('Input: ').strip()
 
@@ -1580,7 +1580,7 @@ def menu_download_from_online_user_bookmark(opisvalid, args):
             if arg == 'y' or arg == 'n' or arg == 'o':
                 hide = arg
             else:
-                print "Invalid args: ", args
+                print("Invalid args: ", args)
                 return
             (start_page, end_page) = get_start_and_end_number_from_args(args, offset=1)
     else:
@@ -1589,7 +1589,7 @@ def menu_download_from_online_user_bookmark(opisvalid, args):
         if arg == 'y' or arg == 'n' or arg == 'o':
             hide = arg
         else:
-            print "Invalid args: ", arg
+            print("Invalid args: ", arg)
             return
         (start_page, end_page) = get_start_and_end_number()
     process_bookmark(hide, start_page, end_page)
@@ -1607,7 +1607,7 @@ def menu_download_from_online_image_bookmark(opisvalid, args):
         if arg == 'y' or arg == 'n' or arg == 'o':
             hide = arg
         else:
-            print "Invalid args: ", args
+            print("Invalid args: ", args)
             return
         (start_page, end_page) = get_start_and_end_number_from_args(args, offset=1)
         if len(args) > 3:
@@ -1618,7 +1618,7 @@ def menu_download_from_online_image_bookmark(opisvalid, args):
         if arg == 'y' or arg == 'n' or arg == 'o':
             hide = arg
         else:
-            print "Invalid args: ", arg
+            print("Invalid args: ", arg)
             return
         tag = raw_input("Tag (default=All Images): ") or ''
         (start_page, end_page) = get_start_and_end_number()
@@ -1702,7 +1702,7 @@ def menu_export_online_bookmark(opisvalid, args):
     if arg == 'y' or arg == 'n' or arg == 'o':
         hide = arg
     else:
-        print "Invalid args: ", arg
+        print("Invalid args: ", arg)
     export_bookmark(filename, hide)
 
 
@@ -1715,7 +1715,7 @@ def menu_export_online_user_bookmark(opisvalid, args):
     if arg.isdigit():
         member_id = arg
     else:
-        print "Invalid args: ", arg
+        print("Invalid args: ", arg)
     export_bookmark(filename, 'n', 1, 0, member_id)
 
 
@@ -1775,7 +1775,7 @@ def main_loop(ewd, op_is_valid, selection, np_is_valid, args):
     while True:
         try:
             if len(__errorList) > 0:
-                print "Unknown errors from previous operation"
+                print("Unknown errors from previous operation")
                 for err in __errorList:
                     message = err["type"] + ": " + str(err["id"]) + " ==> " + err["message"]
                     PixivHelper.print_and_log('error', message)
@@ -1825,10 +1825,10 @@ def main_loop(ewd, op_is_valid, selection, np_is_valid, args):
                 if not np_is_valid:
                     np_is_valid = True
                     np = 0
-                    print 'download all mode activated'
+                    print('download all mode activated')
                 else:
                     np_is_valid = False
-                    print 'download mode reset to', __config__.numberOfPage, 'pages'
+                    print('download mode reset to', __config__.numberOfPage, 'pages')
             elif selection == 'x':
                 break
 
@@ -1838,7 +1838,7 @@ def main_loop(ewd, op_is_valid, selection, np_is_valid, args):
         except KeyboardInterrupt:
             PixivHelper.print_and_log("info", "Keyboard Interrupt pressed, selection: {0}".format(selection))
             PixivHelper.clearScreen()
-            print "Restarting..."
+            print("Restarting...")
             selection = menu()
     return np_is_valid, op_is_valid, selection
 
@@ -1913,7 +1913,7 @@ def main():
         __config__.loadConfig(path=configfile)
         PixivHelper.setConfig(__config__)
     except BaseException:
-        print 'Failed to read configuration.'
+        print('Failed to read configuration.')
         __log__.exception('Failed to read configuration.')
 
     PixivHelper.setLogLevel(__config__.logLevel)
@@ -1957,11 +1957,11 @@ def main():
         if __config__.useList:
             list_txt = PixivListItem.parseList(__config__.downloadListDirectory + os.sep + 'list.txt', __config__.rootDirectory)
             __dbManager__.importList(list_txt)
-            print "Updated " + str(len(list_txt)) + " items."
+            print("Updated " + str(len(list_txt)) + " items.")
 
         if __config__.overwrite:
             msg = 'Overwrite enabled.'
-            print msg
+            print(msg)
             __log__.info(msg)
 
         if __config__.dayLastUpdated != 0 and __config__.processFromDb:
@@ -2007,7 +2007,7 @@ def main():
             username = raw_input('Username ? ')
         else:
             msg = 'Using Username: ' + username
-            print msg
+            print(msg)
             __log__.info(msg)
 
         password = __config__.password
@@ -2020,11 +2020,11 @@ def main():
 
         if np_is_valid and np != 0:  # Yavos: overwrite config-data
             msg = 'Limit up to: ' + str(np) + ' page(s). (set via commandline)'
-            print msg
+            print(msg)
             __log__.info(msg)
         elif __config__.numberOfPage != 0:
             msg = 'Limit up to: ' + str(__config__.numberOfPage) + ' page(s).'
-            print msg
+            print(msg)
             __log__.info(msg)
 
         result = doLogin(password, username)

--- a/setup.py
+++ b/setup.py
@@ -23,25 +23,25 @@ class bcolors:
 
 
 if not isWindows:
-    print (bcolors.FAIL)
-    print ("____________________________")
-    print ("          ERROR           ")
-    print ("----------------------------")
+    print(bcolors.FAIL)
+    print("____________________________")
+    print("          ERROR           ")
+    print("----------------------------")
 
-    print ("Setup.py is used to generate executable under Windows systems\n")
-    print ("For non windows systems please run:\n\n\tpip install -r requirements.txt")
-    print (bcolors.ENDC)
+    print("Setup.py is used to generate executable under Windows systems\n")
+    print("For non windows systems please run:\n\n\tpip install -r requirements.txt")
+    print(bcolors.ENDC)
     if ranWithPy3:
-        print (bcolors.WARNING)
-        print ("Attention: PixivUtil2 is not yet compatible with Python 3.  You have run this script with Python 3.")
-        print ("To install dependancies you will need to use a specific version of pip e.g.:\n")
-        print ("\tpip-2.7 install -r requirements.txt\n")
-        print ("To run you will need to specify python 2.x:\n")
-        print ("\tpython2 PixivUtil2.py\n")
-        print (bcolors.ENDC)
+        print(bcolors.WARNING)
+        print("Attention: PixivUtil2 is not yet compatible with Python 3.  You have run this script with Python 3.")
+        print("To install dependancies you will need to use a specific version of pip e.g.:\n")
+        print("\tpip-2.7 install -r requirements.txt\n")
+        print("To run you will need to specify python 2.x:\n")
+        print("\tpython2 PixivUtil2.py\n")
+        print(bcolors.ENDC)
     else:
-        print ("After installing requirements run with command:\n")
-        print ("\tpython PixivUtil2.py\n")
+        print("After installing requirements run with command:\n")
+        print("\tpython PixivUtil2.py\n")
     exit(-1)
 
 

--- a/test.PixivDBManager.py
+++ b/test.PixivDBManager.py
@@ -26,7 +26,7 @@ class TestPixivDBManager(unittest.TestCase):
         result = DB.selectMembersByLastDownloadDate(7)
         self.assertEqual(len(result), LIST_SIZE)
         for item in result:
-            print item.memberId, item.path
+            print(item.memberId, item.path)
 
     def testSelectAllMember(self):
         DB = PixivDBManager(target="test.db.sqlite")
@@ -35,10 +35,10 @@ class TestPixivDBManager(unittest.TestCase):
         result = DB.selectAllMember()
         self.assertEqual(len(result), LIST_SIZE)
         for item in result:
-            print item.memberId, item.path
+            print(item.memberId, item.path)
 
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(TestPixivDBManager)
     unittest.TextTestRunner(verbosity=5).run(suite)
-    print "================================================================"
+    print("================================================================")

--- a/test.PixivHelper.py
+++ b/test.PixivHelper.py
@@ -40,22 +40,22 @@ class TestPixivHelper(unittest.TestCase):
         imageInfo.imageCount = 100
         page.decompose()
         del page
-        # print imageInfo.PrintInfo()
+        # print(imageInfo.PrintInfo())
         nameFormat = '%member_token% (%member_id%)\%urlFilename% %page_number% %works_date_only% %works_res% %works_tools% %title%'
 
         expected = unicode(u'ffei (554800)\\28865189_p0 001 7-23-2012 複数枚投稿 2P Photoshop C82おまけ本 「沙耶は俺の嫁」サンプル.jpg')
         result = PixivHelper.makeFilename(nameFormat, imageInfo, artistInfo=None, tagsSeparator=' ', fileUrl='http://i2.pixiv.net/img26/img/ffei/28865189_p0.jpg')
-        print result
+        print(result)
         self.assertEqual(result, expected)
 
         expected = unicode(u'ffei (554800)\\28865189_p14 015 7-23-2012 複数枚投稿 2P Photoshop C82おまけ本 「沙耶は俺の嫁」サンプル.jpg')
         result = PixivHelper.makeFilename(nameFormat, imageInfo, artistInfo=None, tagsSeparator=' ', fileUrl='http://i2.pixiv.net/img26/img/ffei/28865189_p14.jpg')
-        print result
+        print(result)
         self.assertEqual(result, expected)
 
         expected = unicode(u'ffei (554800)\\28865189_p921 922 7-23-2012 複数枚投稿 2P Photoshop C82おまけ本 「沙耶は俺の嫁」サンプル.jpg')
         result = PixivHelper.makeFilename(nameFormat, imageInfo, artistInfo=None, tagsSeparator=' ', fileUrl='http://i2.pixiv.net/img26/img/ffei/28865189_p921.jpg')
-        print result
+        print(result)
         self.assertEqual(result, expected)
 
     def testCreateFilenameUnicode(self):
@@ -68,7 +68,7 @@ class TestPixivHelper(unittest.TestCase):
         nameFormat = '%member_token% (%member_id%)\%urlFilename% %works_date_only% %works_res% %works_tools% %title%'
         expected = unicode(u'balzehn (267014)\\2493913 12-23-2008 852x1200 Photoshop SAI つけペン アラクネのいる日常２.jpg')
         result = PixivHelper.makeFilename(nameFormat, imageInfo, artistInfo=None, tagsSeparator=' ', fileUrl='http://i2.pixiv.net/img16/img/balzehn/2493913.jpg')
-        # print result
+        # print(result)
         self.assertEqual(result, expected)
 
     def testCreateAvatarFilenameFormatNoSubfolderNoRootDir(self):
@@ -80,7 +80,7 @@ class TestPixivHelper(unittest.TestCase):
         tagsLimit = 0
         targetDir = ''
         filename = PixivHelper.CreateAvatarFilename(filenameFormat, tagsSeparator, tagsLimit, artist, targetDir)
-        # print filename
+        # print(filename)
         self.assertEqual(filename, self.currPath + os.sep + u'folder.jpg')
 
     def testCreateAvatarFilenameFormatWithSubfolderNoRootDir(self):
@@ -92,7 +92,7 @@ class TestPixivHelper(unittest.TestCase):
         tagsLimit = 0
         targetDir = ''
         filename = PixivHelper.CreateAvatarFilename(filenameFormat, tagsSeparator, tagsLimit, artist, targetDir)
-        # print filename
+        # print(filename)
         self.assertEqual(filename, self.currPath + os.sep + u'kirabara29 (1107124)\\folder.jpg')
 
     def testCreateAvatarFilenameFormatNoSubfolderWithRootDir(self):
@@ -104,7 +104,7 @@ class TestPixivHelper(unittest.TestCase):
         tagsLimit = 0
         targetDir = os.path.abspath('.')
         filename = PixivHelper.CreateAvatarFilename(filenameFormat, tagsSeparator, tagsLimit, artist, targetDir)
-        # print filename
+        # print(filename)
         self.assertEqual(filename, targetDir + os.sep + u'folder.jpg')
 
     def testCreateAvatarFilenameFormatWithSubfolderWithRootDir(self):
@@ -116,7 +116,7 @@ class TestPixivHelper(unittest.TestCase):
         tagsLimit = 0
         targetDir = os.path.abspath('.')
         filename = PixivHelper.CreateAvatarFilename(filenameFormat, tagsSeparator, tagsLimit, artist, targetDir)
-        # print filename
+        # print(filename)
         self.assertEqual(filename, targetDir + os.sep + u'kirabara29 (1107124)\\folder.jpg')
 
     def testCreateAvatarFilenameFormatNoSubfolderWithCustomRootDir(self):
@@ -128,7 +128,7 @@ class TestPixivHelper(unittest.TestCase):
         tagsLimit = 0
         targetDir = 'C:\\images'
         filename = PixivHelper.CreateAvatarFilename(filenameFormat, tagsSeparator, tagsLimit, artist, targetDir)
-        # print filename
+        # print(filename)
         self.assertEqual(filename, u'C:\\images\\folder.jpg')
 
     def testCreateAvatarFilenameFormatWithSubfolderWithCustomRootDir(self):
@@ -140,7 +140,7 @@ class TestPixivHelper(unittest.TestCase):
         tagsLimit = 0
         targetDir = 'C:\\images'
         filename = PixivHelper.CreateAvatarFilename(filenameFormat, tagsSeparator, tagsLimit, artist, targetDir)
-        # print filename
+        # print(filename)
         self.assertEqual(filename, u'C:\\images\\kirabara29 (1107124)\\folder.jpg')
 
     def testParseLoginError(self):
@@ -154,7 +154,7 @@ class TestPixivHelper(unittest.TestCase):
         p = open('./test/test-login-form.html', 'r')
         page = BeautifulSoup(p.read())
         r = page.findAll('form', attrs={'action': '/login.php'})
-        print r
+        print(r)
         self.assertTrue(len(r) > 0)
 
 

--- a/test.PixivModel.py
+++ b/test.PixivModel.py
@@ -31,14 +31,14 @@ class MockPixivBrowser(PixivBrowser):
 
 class TestPixivArtist(unittest.TestCase):
     def testPixivArtistProfileDataSrc(self):
-        # print '\nTesting member page ProfileDataSrc
+        # print('\nTesting member page ProfileDataSrc')
         artist = None
         p = open('./test/test-helper-avatar-name.htm', 'r')
         page = BeautifulSoup(p.read())
         try:
             artist = PixivArtist(1107124, page)
         except PixivException as ex:
-            print ex
+            print(ex)
 
         page.decompose()
         del page
@@ -48,17 +48,17 @@ class TestPixivArtist(unittest.TestCase):
         self.assertGreater(artist.totalImages, 71)
 
     def testPixivArtistNoImage(self):
-        # print '\nTesting member page - no image'
+        # print('\nTesting member page - no image')
         p = open('./test/test-noimage.htm', 'r')
         page = BeautifulSoup(p.read())
         with self.assertRaises(PixivException):
             member = PixivArtist(1233, page)
-            print member.imageList
+            print(member.imageList)
         page.decompose()
         del page
 
     def testPixivArtistNoMember(self):
-        # print '\nTesting member page - no member'
+        # print('\nTesting member page - no member')
         p = open('./test/test-nouser.htm', 'r')
         page = BeautifulSoup(p.read())
         with self.assertRaises(PixivException):
@@ -67,7 +67,7 @@ class TestPixivArtist(unittest.TestCase):
         del page
 
     def testPixivArtistNoAvatar(self):
-        # print '\nTesting member page without avatar image'
+        # print('\nTesting member page without avatar image')
         p = open('./test/test-member-noavatar.htm', 'r')
         artist = None
         page = BeautifulSoup(p.read())
@@ -75,7 +75,7 @@ class TestPixivArtist(unittest.TestCase):
             artist = PixivArtist(26357, page)
             # artist.PrintInfo()
         except PixivException as ex:
-            print ex
+            print(ex)
         page.decompose()
         del page
         self.assertNotEqual(artist, None)
@@ -83,7 +83,7 @@ class TestPixivArtist(unittest.TestCase):
         self.assertEqual(artist.artistToken, 'yukimaruko')
 
     def testPixivArtistSuspended(self):
-        # print '\nTesting member page - suspended member'
+        # print('\nTesting member page - suspended member')
         p = open('./test/test-member-suspended.htm', 'r')
         page = BeautifulSoup(p.read())
         with self.assertRaises(PixivException) as ex:
@@ -102,14 +102,14 @@ class TestPixivArtist(unittest.TestCase):
         del page
 
     def testPixivArtistBookmark(self):
-        # print '\nTesting member page'
+        # print('\nTesting member page')
         p = open('./test/test-member-bookmark.htm', 'r')
         page = BeautifulSoup(p.read())
         try:
             artist = PixivArtist(490219, page)
             # artist.PrintInfo()
         except PixivException as ex:
-            print ex
+            print(ex)
             self.assertTrue(ex is None)
 
         page.decompose()
@@ -119,7 +119,7 @@ class TestPixivArtist(unittest.TestCase):
         self.assertEqual(artist.artistId, 490219)
 
     def testPixivArtistServerError(self):
-        # print '\nTesting member page'
+        # print('\nTesting member page')
         p = open('./test/test-server-error.html', 'r')
         page = BeautifulSoup(p.read())
         with self.assertRaises(PixivException) as ex:
@@ -129,7 +129,7 @@ class TestPixivArtist(unittest.TestCase):
         del page
 
     def testPixivArtistManageSelf(self):
-        # print '\nTesting own page '
+        # print('\nTesting own page ')
         p = open('./test/test-member-self.htm', 'r')
         page = BeautifulSoup(p.read())
         artist = PixivArtist(189816, page)
@@ -145,7 +145,7 @@ class TestPixivArtist(unittest.TestCase):
         self.assertIn(65079382, artist.imageList)
 
     def testPixivArtistManageSelf2(self):
-        # print '\nTesting own page '
+        # print('\nTesting own page ')
         p = open('./test/Error_page_for_member_539661.htm', 'r')
         page = BeautifulSoup(p.read())
         artist = PixivArtist(539661, page)
@@ -172,7 +172,7 @@ class TestPixivImage(unittest.TestCase):
         self.assertEqual(image2.imageId, 32039274)
         self.assertEqual(image2.imageTitle, u"新しいお姫様")
         self.assertTrue(len(image2.imageCaption) > 0)
-        print u"\r\nCaption = {0}".format(image2.imageCaption)
+        print(u"\r\nCaption = {0}".format(image2.imageCaption))
 
         self.assertTrue(u'MAYU' in image2.imageTags)
         self.assertTrue(u'VOCALOID' in image2.imageTags)
@@ -239,7 +239,7 @@ class TestPixivImage(unittest.TestCase):
         self.assertEqual(image2.artist.artistToken, 'hvcv')
 
     def testPixivImageNoAvatar(self):
-        # print '\nTesting artist page without avatar image'
+        # print('\nTesting artist page without avatar image')
         p = open('./test/test-image-noavatar.htm', 'r')
         page = BeautifulSoup(p.read())
         image = PixivImage(20496355, page)
@@ -249,7 +249,7 @@ class TestPixivImage(unittest.TestCase):
         self.assertEqual(image.artist.artistToken, 'iymt')
         self.assertEqual(image.imageId, 20496355)
         # 07/22/2011 03:09｜512×600｜RETAS STUDIO&nbsp;
-        # print image.worksDate, image.worksResolution, image.worksTools
+        # print(image.worksDate, image.worksResolution, image.worksTools)
         self.assertEqual(image.worksDate, '7/22/2011 03:09')
         self.assertEqual(image.worksResolution, '512x600')
         self.assertEqual(image.worksTools, 'RETAS STUDIO')
@@ -260,7 +260,7 @@ class TestPixivImage(unittest.TestCase):
         try:
             image = PixivImage(11164869, page)
         except PixivException as ex:
-            print ex
+            print(ex)
         page.decompose()
         del page
         self.assertNotEqual(image, None)
@@ -268,7 +268,7 @@ class TestPixivImage(unittest.TestCase):
         self.assertEqual(image.worksDate, '6/9/2010 02:33')
         self.assertEqual(image.worksResolution, '1009x683')
         self.assertEqual(image.worksTools, u'SAI')
-        # print image.imageTags
+        # print(image.imageTags)
         joinedResult = " ".join(image.imageTags)
         self.assertEqual(joinedResult.find("VOCALOID") > -1, True)
 
@@ -278,7 +278,7 @@ class TestPixivImage(unittest.TestCase):
         try:
             image = PixivImage(9175987, page)
         except PixivException as ex:
-            print ex
+            print(ex)
         page.decompose()
         del page
         self.assertNotEqual(image, None)
@@ -289,14 +289,14 @@ class TestPixivImage(unittest.TestCase):
         self.assertEqual(image.imageTags, [])
 
     def testPixivImageUnicode(self):
-        # print '\nTesting image page - big'
+        # print('\nTesting image page - big')
         p = open('./test/test-image-unicode.htm', 'r')
         page = BeautifulSoup(p.read())
         try:
             image = PixivImage(2493913, page)
             # image.PrintInfo()
         except PixivException as ex:
-            print ex
+            print(ex)
         page.decompose()
         del page
         self.assertNotEqual(image, None)
@@ -304,7 +304,7 @@ class TestPixivImage(unittest.TestCase):
         self.assertEqual(image.imageMode, 'bigNew')
         self.assertEqual(image.worksDate, '12/23/2008 21:01')
         self.assertEqual(image.worksResolution, '852x1200')
-        # print image.worksTools
+        # print(image.worksTools)
         self.assertEqual(image.worksTools, u'Photoshop SAI つけペン')
 
     def testPixivImageRateCount(self):
@@ -314,7 +314,7 @@ class TestPixivImage(unittest.TestCase):
             image = PixivImage(28865189, page)
             # image.PrintInfo()
         except PixivException as ex:
-            print ex
+            print(ex)
         page.decompose()
         del page
         self.assertNotEqual(image, None)
@@ -327,7 +327,7 @@ class TestPixivImage(unittest.TestCase):
         self.assertEqual(image.worksTools, "Photoshop")
 
     def testPixivImageNoImage(self):
-        # print '\nTesting image page - no image'
+        # print('\nTesting image page - no image')
         p = open('./test/test-image-noimage.htm', 'r')
         page = BeautifulSoup(p.read())
         with self.assertRaises(PixivException):
@@ -336,7 +336,7 @@ class TestPixivImage(unittest.TestCase):
         del page
 
     def testPixivImageDeleted(self):
-        # print '\nTesting image page - deleted image'
+        # print('\nTesting image page - deleted image')
         p = open('./test/test-image-deleted.htm', 'r')
         page = BeautifulSoup(p.read())
         with self.assertRaises(PixivException):
@@ -345,7 +345,7 @@ class TestPixivImage(unittest.TestCase):
         del page
 
     def testPixivImageNoImageEng(self):
-        # print '\nTesting image page - no image'
+        # print('\nTesting image page - no image')
         p = open('./test/test-image-noimage-eng.htm', 'r')
         page = BeautifulSoup(p.read())
         with self.assertRaises(PixivException):
@@ -354,14 +354,14 @@ class TestPixivImage(unittest.TestCase):
         del page
 
     def testPixivImageModeManga(self):
-        # print '\nTesting image page - manga'
+        # print('\nTesting image page - manga')
         p = open('./test/test-image-manga.htm', 'r')
         page = BeautifulSoup(p.read())
         try:
             image = PixivImage(28820443, page)
             # image.PrintInfo()
         except PixivException as ex:
-            print ex
+            print(ex)
         page.decompose()
         del page
         self.assertNotEqual(image, None)
@@ -369,45 +369,45 @@ class TestPixivImage(unittest.TestCase):
         self.assertEqual(image.imageMode, 'manga')
 
     def testPixivImageParseMangaTwoPage(self):
-        # print '\nTesting parse Manga Images'
+        # print('\nTesting parse Manga Images')
         p = open('./test/test-image-manga-2page.htm', 'r')
         page = BeautifulSoup(p.read())
         image = PixivImage()
         urls = image.ParseImages(page, mode='manga')
-        # print urls
+        # print(urls)
         self.assertEqual(len(urls), 11)
         self.assertEqual(len(urls), image.imageCount)
         imageId = urls[0].split('/')[-1].split('.')[0]
-        # print 'imageId:',imageId
+        # print('imageId:',imageId)
         self.assertEqual(imageId, '46322053_p0')
 
     def testPixivImageParseBig(self):
-        # print '\nTesting parse Big Image'
+        # print('\nTesting parse Big Image')
         p = open('./test/test-image-unicode.htm', 'r')
         page = BeautifulSoup(p.read())
         image = PixivImage()
         urls = image.ParseImages(page, mode='big')
         self.assertEqual(len(urls), 1)
-        print urls[0]
+        print(urls[0])
         imageId = urls[0].split('/')[-1].split('_')[0]
-        # print 'imageId:',imageId
+        # print('imageId:',imageId)
         self.assertEqual(int(imageId), 2493913)
 
     def testPixivImageParseManga(self):
-        # print '\nTesting parse Manga Images'
+        # print('\nTesting parse Manga Images')
         p = open('./test/test-image-parsemanga.htm', 'r')
         page = BeautifulSoup(p.read())
         image = PixivImage()
         urls = image.ParseImages(page, mode='manga', _br=MockPixivBrowser(None))
-        # print urls
+        # print(urls)
         self.assertEqual(len(urls), 3)
         self.assertEqual(len(urls), image.imageCount)
         imageId = urls[0].split('/')[-1].split('.')[0]
-        # print 'imageId:',imageId
+        # print('imageId:',imageId)
         self.assertEqual(imageId, '46279245_p0')
 
     def testPixivImageParseMangaBig(self):
-        # print '\nTesting parse Manga Images'
+        # print('\nTesting parse Manga Images')
         # Issue #224
         p = open('./test/test-image-big-manga.html', 'r')
         page = BeautifulSoup(p.read())
@@ -415,13 +415,13 @@ class TestPixivImage(unittest.TestCase):
         image.ParseInfo(page)
         urls = image.ParseImages(page, mode=image.imageMode, _br=MockPixivBrowser(1))
         self.assertEqual(len(urls), 1)
-        print urls[0]
+        print(urls[0])
         imageId = urls[0].split('/')[-1].split('_')[0]
-        # print 'imageId:',imageId
+        # print('imageId:',imageId)
         self.assertEqual(int(imageId), 62670665)
 
     def testPixivImageNoLogin(self):
-        # print '\nTesting not logged in'
+        # print('\nTesting not logged in')
         p = open('./test/test-image-nologin.htm', 'r')
         page = BeautifulSoup(p.read())
         try:
@@ -431,7 +431,7 @@ class TestPixivImage(unittest.TestCase):
             self.assertEqual(ex.errorCode, PixivException.NOT_LOGGED_IN)
 
     def testPixivImageServerError(self):
-        # print '\nTesting image page'
+        # print('\nTesting image page')
         p = open('./test/test-server-error.html', 'r')
         page = BeautifulSoup(p.read())
         with self.assertRaises(PixivException) as ex:
@@ -441,7 +441,7 @@ class TestPixivImage(unittest.TestCase):
         del page
 
     def testPixivImageServerError2(self):
-        # print '\nTesting image page'
+        # print('\nTesting image page')
         p = open('./test/test-image-generic-error.html', 'r')
         page = BeautifulSoup(p.read())
         with self.assertRaises(PixivException) as ex:
@@ -451,12 +451,12 @@ class TestPixivImage(unittest.TestCase):
         del page
 
     def testPixivImageUgoira(self):
-        # print '\nTesting image page'
+        # print('\nTesting image page')
         p = open('./test/test-image-ugoira.htm', 'r')
         page = BeautifulSoup(p.read())
         image = PixivImage(46281014, page)
         urls = image.ParseImages(page)
-        print image.imageUrls
+        print(image.imageUrls)
         self.assertTrue(image.imageUrls[0].find(".zip") > -1)
         page.decompose()
         del page
@@ -472,7 +472,7 @@ class TestPixivImage(unittest.TestCase):
         self.assertEqual(image2.imageId, 65079382)
         self.assertEqual(image2.imageTitle, u"Test")
         self.assertTrue(len(image2.imageCaption) > 0)
-        print u"\r\nCaption = {0}".format(image2.imageCaption)
+        print(u"\r\nCaption = {0}".format(image2.imageCaption))
 
         self.assertTrue(u'None' in image2.imageTags)
 
@@ -483,7 +483,7 @@ class TestPixivImage(unittest.TestCase):
 
 class TestPixivBookmark(unittest.TestCase):
     def testPixivBookmarkNewIlust(self):
-        # print '\nTesting BookmarkNewIlust'
+        # print('\nTesting BookmarkNewIlust')
         p = open('./test/test-bookmarks_new_ilust.htm', 'r')
         page = BeautifulSoup(p.read())
         result = PixivNewIllustBookmark(page)
@@ -491,7 +491,7 @@ class TestPixivBookmark(unittest.TestCase):
         self.assertEqual(len(result.imageList), 20)
 
     def testPixivImageBookmark(self):
-        # print '\nTesting PixivImageBookmark'
+        # print('\nTesting PixivImageBookmark')
         p = open('./test/test-image-bookmark.htm', 'r')
         page = BeautifulSoup(p.read())
         result = PixivBookmark.parseImageBookmark(page)
@@ -503,7 +503,7 @@ class TestPixivBookmark(unittest.TestCase):
         self.assertTrue(30119925 in result)
 
     def testPixivImageBookmarkMember(self):
-        # print '\nTesting PixivImageBookmark'
+        # print('\nTesting PixivImageBookmark')
         p = open('./test/test-image-bookmark-member.htm', 'r')
         page = BeautifulSoup(p.read())
         result = PixivBookmark.parseImageBookmark(page)
@@ -586,7 +586,7 @@ class TestPixivTags(unittest.TestCase):
         image = PixivTags()
         image.parseTags(page)
         for img in image.itemList:
-            print img.imageId
+            print(img.imageId)
         self.assertEqual(len(image.itemList), 40)
         self.assertEqual(image.isLastPage, False)
 

--- a/test.updateHtml.py
+++ b/test.updateHtml.py
@@ -31,7 +31,7 @@ def prepare():
 
 
 def downloadPage(url, filename):
-    print "Dumping " + url + " to " + filename
+    print("Dumping " + url + " to " + filename)
     try:
         html = __br__.open(url).read()
     except mechanize.HTTPError as e:
@@ -102,12 +102,12 @@ def main():
         # ./test/test-member-suspended.htm
         # ./test/test-member-nologin.htm
 
-        print "Completed"
+        print("Completed")
 
 
 if __name__ == '__main__':
     try:
         main()
     except Exception as ex:
-        print ex
+        print(ex)
     raw_input("anykey")


### PR DESCRIPTION
related #325 

this is not included fix for `print` with trailing space.

based on this https://stackoverflow.com/questions/4009672/python-trailing-comma-after-print-executes-next-instruction

there is no python2/3 compatibilities code, so the fix is probably using this format

```python
if six.PY3:
    print('Some text', end='')
else:
    print 'Some text',
```

and because of that fix, it require six library (which later can be useful to port to python3 code).

but for now because it add additional dependencies, i will put it on hold