### PR TITLE
setup for non windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,11 @@ import os
 import sys
 try:
     from setuptools import setup, convert_path, find_packages
+    SETUPTOOLS_USED = True
 except ImportError:
     from distutils.core import setup, find_packages
     from distutils.util import convert_path
+    SETUPTOOLS_USED = False
 
 isWindows = os.name is 'nt'
 ranWithPy3 = sys.version_info >= (3, 0)
@@ -56,6 +58,13 @@ if not isWindows:
     setup_kwargs = dict(
         entry_points={'console_scripts': ['PixivUtil2 = PixivUtil2:main', ]})
 
+if SETUPTOOLS_USED:
+    setup_kwargs['project_urls'] = {
+        'Bug Reports': 'https://github.com/Nandaka/PixivUtil2/issues',
+        'Funding': 'https://bit.ly/PixivUtilDonation',
+        'Source': 'https://github.com/Nandaka/PixivUtil2',
+    }
+
 # get install_requires
 here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'requirements.txt')) as f:
@@ -97,10 +106,5 @@ setup(
     keywords='pixiv downloader',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     install_requires=install_requires,
-    project_urls={  # Optional
-        'Bug Reports': 'https://github.com/Nandaka/PixivUtil2/issues',
-        'Funding': 'https://bit.ly/PixivUtilDonation',
-        'Source': 'https://github.com/Nandaka/PixivUtil2',
-    },
     **setup_kwargs
 )

--- a/setup.py
+++ b/setup.py
@@ -67,11 +67,10 @@ ver_path = convert_path('PixivConstant.py')
 with open(ver_path) as ver_file:
     exec(ver_file.read(), main_ns)
 version = main_ns['PIXIVUTIL_VERSION']
+v_parts = version.split('-', 1)
+main_version = '{0}.{1}.{2}'.format(v_parts[0][0:4], int(v_parts[0][4:6]), int(v_parts[0][6:7]))
 if '-' in version:
-    v_parts = version.split('-', 1)
-    version = '{}.0.0.{}'.format(v_parts[0], v_parts[1])
-else:
-    version = '{}.0.0'.format(version)
+    version = main_version + '.{}'.format(v_parts[1])
 # get long_description
 readme_path = convert_path('readme.txt')
 with open(readme_path) as readme_file:

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,8 @@ v_parts = version.split('-', 1)
 main_version = '{0}.{1}.{2}'.format(v_parts[0][0:4], int(v_parts[0][4:6]), int(v_parts[0][6:7]))
 if '-' in version:
     version = main_version + '.{}'.format(v_parts[1])
+else:
+    version = main_version
 # get long_description
 readme_path = convert_path('readme.txt')
 with open(readme_path) as readme_file:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # -*- coding: UTF-8 -*-
 from __future__ import print_function
 
-from distutils.core import setup
 from os import path
 import os
 import sys


### PR DESCRIPTION
with this it is possible to pip install the program, or even if you want upload it to pypi for easier deployment.

changes:

- prefer setuptools instead of disutils, reference: https://stackoverflow.com/questions/25337706/setuptools-vs-distutils-why-is-distutils-still-a-thing
- on non windows, the program will be run with `PixivUtil2`. it can be changed e.g. `PixivUtil2.py`, but i remove the `.py` extension to differentiate that it is command line.
- required package is looked up from `requirements.txt`   file. the reading method is taken from the reading method for program version. this is not foolproof. if the project require requirement, which starting with `git+` it have to be changed.
- method to get program version is taken from here https://stackoverflow.com/a/24517154/1766261
- program version is tried to use semver version. it mean `v20180218` will be `20180218.0.0` and `20180227-beta3` will be `20180227.0.0.beta3`
- no easy way for readme file. pypi require rst file and i have to convert the current readme into rst . rendered version for pypi can be found here https://test.pypi.org/project/PixivUtil2/ . uploaded file can be found here https://github.com/rachmadaniHaryono/PixivUtil2/blob/feature/readme-rst/readme.rst
- i don't know your email so leave `author_email` empty
- argument on `setup.py` is ordered based on this https://github.com/pypa/sampleproject/blob/master/setup.py