### PR TITLE
exclude html files on test folder for github linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+test/*.htm linguist-vendored=False
+test/*.html linguist-vendored=False


### PR DESCRIPTION
doc on method https://github.com/github/linguist#vendored-code

with this PixivUtil2 will be properly recognized as python instead of html program

see branch language analyze result https://github.com/rachmadaniHaryono/PixivUtil2/tree/feature/exclude-html-test-folder