### PR TITLE
 Feature/py3 test compatibility

### DIFF
--- a/PixivModel.py
+++ b/PixivModel.py
@@ -44,12 +44,12 @@ class PixivArtist:
             # detect if there is any other error
             errorMessage = self.IsErrorExist(page)
             if errorMessage is not None:
-                raise PixivException('Member Error: ' + errorMessage, errorCode=PixivException.OTHER_MEMBER_ERROR, htmlPage=page)
+                raise PixivException('Member Error: ' + str(errorMessage), errorCode=PixivException.OTHER_MEMBER_ERROR, htmlPage=page)
 
             # detect if there is server error
             errorMessage = self.IsServerErrorExist(page)
             if errorMessage is not None:
-                raise PixivException('Member Error: ' + errorMessage, errorCode=PixivException.SERVER_ERROR, htmlPage=page)
+                raise PixivException('Member Error: ' + str(errorMessage), errorCode=PixivException.SERVER_ERROR, htmlPage=page)
 
             # detect if image count != 0
             if not fromImage:
@@ -793,7 +793,7 @@ class PixivListItem:
                     parsed = urlparse.urlparse(items[0])
                     if parsed.path == "/member.php" or parsed.path == "/member_illust.php":
                         query_str = urlparse.parse_qs(parsed.query)
-                        if query_str.has_key("id"):
+                        if 'id' in query_str:
                             member_id = int(query_str["id"][0])
                         else:
                             PixivHelper.print_and_log('error', "Cannot detect member id from url: " + items[0])
@@ -1123,16 +1123,16 @@ class PixivGroup:
         self.externalImageList = list()
 
         for imageData in data["imageArticles"]:
-            if imageData["detail"].has_key("id"):
+            if "id" in imageData["detail"]:
                 # hosted in pixiv
                 imageId = imageData["detail"]["id"]
                 self.imageList.append(imageId)
-            elif imageData["detail"].has_key("fullscale_url"):
+            elif "fullscale_url" in imageData["detail"]:
                 # external images?
                 fullscale_url = imageData["detail"]["fullscale_url"]
                 member_id = PixivArtist()
                 member_id.artistId = imageData["user_id"]
-                if imageData.has_key("user_name"):
+                if "user_name" in imageData:
                     member_id.artistName = imageData["user_name"]
                     member_id.artistAvatar = self.parseAvatar(imageData["img"])
                     member_id.artistToken = self.parseToken(imageData["img"])

--- a/PixivModelWhiteCube.py
+++ b/PixivModelWhiteCube.py
@@ -59,7 +59,7 @@ class PixivArtist(PixivModel.PixivArtist):
 
         if page is not None:
             if fromImage:
-                key = page["preload"]["user"].keys()[0]
+                key = list(page["preload"]["user"].keys())[0]
                 root = page["preload"]["user"][key]
 
                 self.artistId = root["userId"]
@@ -148,15 +148,15 @@ class PixivImage(PixivModel.PixivImage):
                 # detect if there is any other error
                 errorMessage = self.IsErrorExist(page)
                 if errorMessage is not None:
-                    raise PixivException('Image Error: ' + errorMessage, errorCode=PixivException.UNKNOWN_IMAGE_ERROR, htmlPage=page)
+                    raise PixivException('Image Error: ' + str(errorMessage), errorCode=PixivException.UNKNOWN_IMAGE_ERROR, htmlPage=page)
                 # detect if there is server error
                 errorMessage = self.IsServerErrorExist(page)
                 if errorMessage is not None:
-                    raise PixivException('Image Error: ' + errorMessage, errorCode=PixivException.SERVER_ERROR, htmlPage=page)
+                    raise PixivException('Image Error: ' + str(errorMessage), errorCode=PixivException.SERVER_ERROR, htmlPage=page)
 
             # parse artist information
             if parent is None:
-                temp_artist_id = payload["preload"]["user"].keys()[0]
+                temp_artist_id = list(payload["preload"]["user"].keys())[0]
                 self.artist = PixivArtist(temp_artist_id, page, fromImage=True)
 
             if fromBookmark and self.originalArtist is None:
@@ -171,7 +171,7 @@ class PixivImage(PixivModel.PixivImage):
             self.ParseInfo(payload)
 
     def ParseInfo(self, page):
-        key = page["preload"]["illust"].keys()[0]
+        key = list(page["preload"]["illust"].keys())[0]
         assert(str(key) == str(self.imageId))
         root = page["preload"]["illust"][key]
 


### PR DESCRIPTION
this pr target is not to replace all the occurrence of the error source but only where it impact the test.

- doing this `'sometext' + errorMessage` will not work if errorMessage is a bytes type variable.
- `dict.has_key` is deprecated. doc https://docs.python.org/2/library/stdtypes.html#dict.has_key , guide https://portingguide.readthedocs.io/en/latest/dicts.html
- `dict.keys` will later return view instead of list, doc https://portingguide.readthedocs.io/en/latest/dicts.html?highlight=dict.keys#dict-views-and-iterators, SO https://stackoverflow.com/questions/16819222/how-to-return-dictionary-keys-as-a-list-in-python

e: based on this https://github.com/rachmadaniHaryono/PixivUtil2/commit/8a4d03f5d9bf1a4a91b6c2810adc7812a0a5dcca , there is a lot more place where `has_key` can be replaced until it can download image on python3. 

if you are interested i can split that commit and add to this commit