### PR TITLE
Fix LocalUTCOffsetTimezone string format for negative timezones

### DIFF
--- a/PixivHelper.py
+++ b/PixivHelper.py
@@ -966,8 +966,8 @@ class LocalUTCOffsetTimezone(tzinfo):
         self.name = time.tzname[0] if not is_dst and len(time.tzname) > 1 else time.tzname[1]
 
     def __str__(self):
-        offset1 = int(self.offset / 60 / 60)
-        offset2 = int(self.offset / 60 % 60)
+        offset1 = abs(int(self.offset / 60 / 60))
+        offset2 = abs(int(self.offset / 60 % 60))
         return "{0}{1:02d}:{2:02d}".format("-" if self.offset < 0 else "+", offset1, offset2)
 
     def __repr__(self):


### PR DESCRIPTION
For all timezones to the West of UTC, the current code formats it wrong. For instance, I live in the EST timezone, and the generated offset string is currently `--5:00` instead of the proper `-05:00`. The `X-Client-Time` header is thus always invalid, which is why #565 was happening to me.