### PR TITLE
Test UTF8_FS: don't use original filename

### DIFF
--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -131,7 +131,7 @@ def download_image(url, filename, referer, overwrite, max_retry, backup_old_file
 
     # test once and set the result
     if UTF8_FS is None:
-        filename_test = filename_save + "あいうえお"
+        filename_test = os.path.dirname(filename_save) + os.sep + "あいうえお"
         try:
             PixivHelper.makeSubdirs(filename_test)
             test_utf = open(filename_test + '.test', "wb")


### PR DESCRIPTION
If original filename is long, adding "あいうえお.test" could make filename to exceeding max chars and causes an error.
Avoid causing the error by not using the original filename. 
Maybe "あいうえお" is enough to check UTF8 support.

Related to fixing #525