### PR TITLE
Avoid duplicates of Fanbox posts cover image

### DIFF
--- a/PixivModelFanbox.py
+++ b/PixivModelFanbox.py
@@ -136,7 +136,7 @@ class FanboxPost(object):
         self.imageTitle = jsPost["title"]
 
         self.coverImageUrl = jsPost["coverImageUrl"]
-        if self.coverImageUrl is not None:
+        if self.coverImageUrl is not None and self.coverImageUrl not in self.embeddedFiles:
             self.embeddedFiles.append(jsPost["coverImageUrl"])
 
         self.worksDate = jsPost["publishedDatetime"]


### PR DESCRIPTION
If the url of cover image is already in embeddedFiles of the post, skip appending the url to it.
Or we can I first check whether self.coverImageUrl is None or not. If it is, then the url will be assigned to self.coverImageUrl, and appended to self.embeddedFiles.
But I think this modifies the codes the least....