### PR TITLE
Progress bar print fix

### DIFF
--- a/PixivHelper.py
+++ b/PixivHelper.py
@@ -644,10 +644,10 @@ def print_progress(curr, total):
     # [12345678901234567890]
     # [||||||||------------]
     animBarLen = 20
-
+    print('\r', end=' ')
     if total > 0:
         complete = int((curr * animBarLen) / total)
-        print(f"[{'|' * complete:{animBarLen}}] {size_in_str(curr)} of {size_in_str(total)}", end='\r')
+        print(f"[{'|' * complete:{animBarLen}}] {size_in_str(curr)} of {size_in_str(total)}", end=' ')
     else:
         # indeterminite
         pos = curr % (animBarLen + 3)  # 3 corresponds to the length of the '|||' below
@@ -655,7 +655,7 @@ def print_progress(curr, total):
         # Use nested replacement field to specify the precision value. This limits the maximum print
         # length of the progress bar. As pos changes, the starting print position of the anim string
         # also changes, thus producing the scrolling effect.
-        print(f'[{anim[animBarLen + 3 - pos:]:.{animBarLen}}] {size_in_str(curr)}', end='\r')
+        print(f'[{anim[animBarLen + 3 - pos:]:.{animBarLen}}] {size_in_str(curr)}', end=' ')
 
 
 def generate_search_tag_url(tags, page, title_caption, wild_card, oldest_first,


### PR DESCRIPTION
https://github.com/Nandaka/PixivUtil2/pull/660#issuecomment-609050617

Hey.  After #660 , there's some thing funny showing when I launch from source code in cmd.
When downloading:
![20200404233041](https://user-images.githubusercontent.com/17560146/78455527-85028a00-76d1-11ea-874f-b22e295e79df.png)
Download completed:
![20200404233242](https://user-images.githubusercontent.com/17560146/78455532-89c73e00-76d1-11ea-839f-749da5b257a7.png)
Before, it's like this
![20200404234211](https://user-images.githubusercontent.com/17560146/78455536-8d5ac500-76d1-11ea-8717-254b71ff6009.png)

I think this whole funny print(?) is because the location of "\r" is changed from end to beginning. 
Before then "\r" was printed first when print_progress was called and ends with a " ", and when the file is downloaded, the "completes in ..." was printed after that.
But now "\r" is printed last, and when the file is downloaded, which means the last "print_progress" was called, the cursor was moved to the beginning, and then the whole "completes ...." sentence is printed from the start, which is shorter than the progress bar.

And for the first image, is also because of the code in the link below, no idea what it means. It just prints "                       0 bytes" on my side. Maybe it was meant to be overwritten by the "\r" and progress bar? Like a place holder?
https://github.com/Nandaka/PixivUtil2/blob/1bc227b4666bcf0f7737daa1c1147e8fd69e1de8/PixivHelper.py#L593