### PR TITLE
Update `autoAddMember`

### DIFF
--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -505,6 +505,9 @@ def process_member(member_id, user_dir='', page=1, end_page=0, bookmark=False, t
                                        __config__.backupOldFile)
                 is_avatar_downloaded = True
 
+            if __config__.autoAddMember:
+                __dbManager__.insertNewMember(int(member_id))
+
             __dbManager__.updateMemberName(member_id, artist.artistName)
 
             if not artist.haveImages:
@@ -608,9 +611,6 @@ def process_member(member_id, user_dir='', page=1, end_page=0, bookmark=False, t
             log_message = 'last image_id: ' + str(image_id)
         else:
             log_message = 'no images were found'
-
-        if __config__.autoAddMember:
-            __dbManager__.insertNewMember(int(member_id))
 
         print('Done.\n')
         __log__.info('Member_id: %d complete, %s', member_id, log_message)


### PR DESCRIPTION
This PR is to make a small change to to the process_member function, changing the order in which a new member is added to the database.

With the current layout, statements such as `__dbManager__.updateLastDownloadedImage(member_id, image_id)` may fail to execute properly because SQLite's Update will not create new rows if an insert is performed on a non-existing row.

This PR moves the call to `insertNewMember` up to line 508 from 612.