### PR TITLE
FANBOX download enhancement

### DIFF
--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -313,7 +313,7 @@ class PixivBrowser(mechanize.Browser):
             login_cookie = self._config.cookieFanbox
 
         if len(login_cookie) > 0:
-            PixivHelper.print_and_log('info', 'Trying to log in with saved cookie')
+            PixivHelper.print_and_log('info', 'Trying to log in FANBOX with saved cookie')
             self.clearCookie()
             self._loadCookie(login_cookie, "fanbox.cc")
 
@@ -321,10 +321,15 @@ class PixivBrowser(mechanize.Browser):
             req.add_header('Accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8')
             req.add_header('Origin', 'https://www.fanbox.cc')
             req.add_header('User-Agent', self._config.useragent)
-            res = self.open_with_retry(req)
-            parsed = BeautifulSoup(res, features="html5lib").decode('utf-8')
-            PixivHelper.get_logger().info('Logging in, return url: %s', res.geturl())
-            res.close()
+            try:
+                res = self.open_with_retry(req)
+                parsed = BeautifulSoup(res, features="html5lib").decode('utf-8')
+                PixivHelper.get_logger().info('Logging in, return url: %s', res.geturl())
+                res.close()
+            except BaseException as e:
+                PixivHelper.get_logger().error('Error at fanboxLoginUsingCookie, please check cookieFanbox: '
+                                               + format(sys.exc_info()))
+                return False
 
             result = False
             if '"user":{"isLoggedIn":true' in str(parsed):

--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -725,14 +725,30 @@ class PixivBrowser(mechanize.Browser):
                     PixivHelper.toUnicode(response)))
 
     def fanboxGetSupportedUsers(self):
-        ''' get all supported users from the list from https://fanbox.pixiv.net/api/plan.listSupporting'''
-        url = 'https://fanbox.pixiv.net/api/plan.listSupporting'
+        url = 'https://api.fanbox.cc/plan.listSupporting'
         PixivHelper.print_and_log('info', f'Getting supported artists from {url}')
-        referer = "https://www.pixiv.net/fanbox/support/creators"
+        referer = "https://www.fanbox.cc/creators/supporting"
         req = mechanize.Request(url)
         req.add_header('Accept', 'application/json, text/plain, */*')
         req.add_header('Referer', referer)
-        req.add_header('Origin', 'https://www.pixiv.net')
+        req.add_header('Origin', 'https://www.fanbox.cc')
+        req.add_header('User-Agent', self._config.useragent)
+
+        res = self.open_with_retry(req)
+        # read the json response
+        response = res.read()
+        res.close()
+        result = Fanbox(response)
+        return result
+
+    def fanboxGetFollowedUsers(self):
+        url = 'https://api.fanbox.cc/creator.listFollowing'
+        PixivHelper.print_and_log('info', f'Getting supported artists from {url}')
+        referer = "https://www.fanbox.cc/creators/following"
+        req = mechanize.Request(url)
+        req.add_header('Accept', 'application/json, text/plain, */*')
+        req.add_header('Referer', referer)
+        req.add_header('Origin', 'https://www.fanbox.cc')
         req.add_header('User-Agent', self._config.useragent)
 
         res = self.open_with_retry(req)
@@ -778,21 +794,6 @@ class PixivBrowser(mechanize.Browser):
 
         for post in result.posts:
             js = self.fanboxGetPost(post.imageId, artist_id)
-                                                                     
-                                                                                   
-                                                                                               
-                                                                                
-                                            
-                                                                           
-                                                  
-                                                               
-                                                                  
-
-                                               
-                                     
-                                                                     
-                         
-                                           
             post.parsePost(js["body"])
 
         return result

--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -268,6 +268,7 @@ class PixivBrowser(mechanize.Browser):
 
     def loginUsingCookie(self, login_cookie=None):
         """  Log in to Pixiv using saved cookie, return True if success """
+        result = False
 
         if login_cookie is None or len(login_cookie) == 0:
             login_cookie = self._config.cookie
@@ -281,7 +282,6 @@ class PixivBrowser(mechanize.Browser):
             PixivHelper.get_logger().info('Logging in, return url: %s', res.geturl())
             res.close()
 
-            result = False
             if "logout.php" in str(parsed):
                 result = True
             if "pixiv.user.loggedIn = true" in str(parsed):
@@ -303,11 +303,12 @@ class PixivBrowser(mechanize.Browser):
                 PixivHelper.get_logger().info('Failed to log in using cookie')
                 PixivHelper.print_and_log('info', 'Cookie already expired/invalid.')
 
-        del parsed
+            del parsed
         return result
 
     def fanboxLoginUsingCookie(self, login_cookie=None):
         """  Log in to Pixiv using saved cookie, return True if success """
+        result = False
 
         if login_cookie is None or len(login_cookie) == 0:
             login_cookie = self._config.cookieFanbox
@@ -324,14 +325,13 @@ class PixivBrowser(mechanize.Browser):
             try:
                 res = self.open_with_retry(req)
                 parsed = BeautifulSoup(res, features="html5lib").decode('utf-8')
-                PixivHelper.get_logger().info('Logging in, return url: %s', res.geturl())
+                PixivHelper.get_logger().info('Logging in with cookit to Fanbox, return url: %s', res.geturl())
                 res.close()
             except BaseException as e:
                 PixivHelper.get_logger().error('Error at fanboxLoginUsingCookie, please check cookieFanbox: '
                                                + format(sys.exc_info()))
                 return False
 
-            result = False
             if '"user":{"isLoggedIn":true' in str(parsed):
                 result = True
 
@@ -342,7 +342,7 @@ class PixivBrowser(mechanize.Browser):
                 PixivHelper.get_logger().info('Failed to log in using cookie')
                 PixivHelper.print_and_log('info', 'Cookie already expired/invalid.')
 
-        del parsed
+            del parsed
         return result
 
     def login(self, username, password):

--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # pylint: disable=W0603, C0325
 
 import http.client
@@ -20,7 +20,7 @@ import PixivHelper
 from PixivArtist import PixivArtist
 from PixivException import PixivException
 from PixivImage import PixivImage
-from PixivModelFanbox import Fanbox, FanboxArtist
+from PixivModelFanbox import Fanbox, FanboxArtist, FanboxPost
 from PixivOAuth import PixivOAuth
 from PixivTags import PixivTags
 
@@ -777,25 +777,55 @@ class PixivBrowser(mechanize.Browser):
         result.artistToken = pixivArtist.artistToken
 
         for post in result.posts:
-            # https://fanbox.pixiv.net/api/post.info?postId=279561
-            # https://www.pixiv.net/fanbox/creator/104409/post/279561
-            p_url = f"https://fanbox.pixiv.net/api/post.info?postId={post.imageId}"
-            p_referer = f"https://www.pixiv.net/fanbox/creator/{artist_id}/post/{post.imageId}"
-            PixivHelper.get_logger().debug('Getting post detail from %s', p_url)
-            p_req = mechanize.Request(p_url)
-            p_req.add_header('Accept', 'application/json, text/plain, */*')
-            p_req.add_header('Referer', p_referer)
-            p_req.add_header('Origin', 'https://www.pixiv.net')
-            p_req.add_header('User-Agent', self._config.useragent)
+            js = self.fanboxGetPost(post.imageId, artist_id)
+                                                                     
+                                                                                   
+                                                                                               
+                                                                                
+                                            
+                                                                           
+                                                  
+                                                               
+                                                                  
 
-            p_res = self.open_with_retry(p_req)
-            p_response = p_res.read()
-            PixivHelper.get_logger().debug(p_response.decode('utf8'))
-            p_res.close()
-            js = demjson.decode(p_response)
+                                               
+                                     
+                                                                     
+                         
+                                           
             post.parsePost(js["body"])
 
         return result
+
+    def fanboxGetPost(self, post_id, member_id=0):
+        # https://fanbox.pixiv.net/api/post.info?postId=279561
+        # https://www.pixiv.net/fanbox/creator/104409/post/279561
+        p_url = f"https://fanbox.pixiv.net/api/post.info?postId={post_id}"
+        # referer doesn't seeem to be essential
+        p_referer = f"https://www.pixiv.net/fanbox/creator/{member_id}/post/{post_id}"
+        PixivHelper.get_logger().debug('Getting post detail from %s', p_url)
+        p_req = mechanize.Request(p_url)
+        p_req.add_header('Accept', 'application/json, text/plain, */*')
+        p_req.add_header('Referer', p_referer)
+        p_req.add_header('Origin', 'https://www.pixiv.net')
+        p_req.add_header('User-Agent', self._config.useragent)
+
+        p_res = self.open_with_retry(p_req)
+        p_response = p_res.read()
+        PixivHelper.get_logger().debug(p_response.decode('utf8'))
+        p_res.close()
+        js = demjson.decode(p_response)
+        if member_id:
+            return js
+        else:
+            _tzInfo = None
+            if self._config.useLocalTimezone:
+                _tzInfo = PixivHelper.LocalUTCOffsetTimezone()
+            user = object().__new__(FanboxArtist)
+            user.artistId = js["body"]["user"]["userId"]
+            user.name = js["body"]["user"]["name"]
+            post = FanboxPost(post_id, user, js["body"], _tzInfo)
+            return post
 
 
 def getBrowser(config=None, cookieJar=None):

--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -111,6 +111,7 @@ class PixivConfig():
         ConfigItem("Authentication", "username", ""),
         ConfigItem("Authentication", "password", ""),
         ConfigItem("Authentication", "cookie", ""),
+        ConfigItem("Authentication", "cookieFanbox", ""),
         ConfigItem("Authentication", "refresh_token", ""),
 
         ConfigItem("Pixiv", "numberOfPage", 0),

--- a/PixivDBManager.py
+++ b/PixivDBManager.py
@@ -85,7 +85,20 @@ class PixivDBManager(object):
                             PRIMARY KEY (image_id, page)
                             )''')
             self.conn.commit()
-
+            
+            # just to keep track of posts, not to record the details, so no columns like saved_to or caption or whatsoever
+            c.execute('''CREATE TABLE IF NOT EXISTS fanbox_master_post (
+                            member_id INTEGER,
+                            post_id INTEGER PRIMARY KEY ON CONFLICT IGNORE,
+                            title TEXT,
+                            fee_required INTEGER,
+                            published_date DATE,
+                            updated_date DATE,
+                            post_type TEXT,
+                            last_update_date DATE
+                            )''')
+            self.conn.commit()
+            
             print('done.')
         except BaseException:
             print('Error at createDatabase():', str(sys.exc_info()))
@@ -102,6 +115,13 @@ class PixivDBManager(object):
 
             c.execute('''DROP TABLE IF EXISTS pixiv_master_image''')
             self.conn.commit()
+            
+            c.execute('''DROP TABLE IF EXISTS pixiv_manga_image''')
+            self.conn.commit()
+
+            c.execute('''DROP TABLE IF EXISTS fanbox_master_post''')
+            self.conn.commit()
+            
         except BaseException:
             print('Error at dropDatabase():', str(sys.exc_info()))
             print('failed.')
@@ -211,6 +231,33 @@ class PixivDBManager(object):
             c.close()
         print('done.')
 
+   def exportFanboxPostList(self, filename):
+        print('Exporting FANBOX post list...', end=' ')
+        try:
+            c = self.conn.cursor()
+            c.execute('''SELECT * FROM fanbox_master_post
+                            ORDER BY member_id, post_id''')
+            filename = filename + '.csv'
+            writer = codecs.open(filename, 'wb', encoding='utf-8')
+            writer.write(
+                'member_id,post_id,title,fee_required,published_date,update_date,post_type,last_update_date\r\n')
+            for row in c:
+                for string in row:
+                    # Unicode write!!
+                    data = str(string)
+                    writer.write(data)
+                    writer.write(',')
+                writer.write('\r\n')
+            writer.write('###END-OF-FILE###')
+            writer.close()
+        except BaseException:
+            print('Error at exportFanboxPostList(): ' + str(sys.exc_info()))
+            print('failed')
+            raise
+        finally:
+            c.close()
+        print('done.')
+        
 ##########################################
 # III. Print DB                          #
 ##########################################
@@ -519,6 +566,73 @@ class PixivDBManager(object):
         finally:
             c.close()
 
+def insertPost(self, member_id, post_id, title, fee_required, published_date, post_type):
+        try:
+            c = self.conn.cursor()
+            post_id = int(post_id)
+            c.execute(
+                '''INSERT OR IGNORE INTO fanbox_master_post (member_id, post_id, last_update_date)
+                VALUES(?, ?, datetime('now'))''', (member_id, post_id))
+            c.execute(
+                '''UPDATE fanbox_master_post SET title = ?, fee_required = ?, published_date = ?, post_type = ?
+                WHERE post_id = ?''',
+                (title, fee_required, published_date, post_type, post_id))
+            self.conn.commit()
+        except BaseException:
+            print('Error at insertPost():', str(sys.exc_info()))
+            print('failed')
+            raise
+        finally:
+            c.close()
+
+    def selectPostByPostId(self, post_id):
+        try:
+            c = self.conn.cursor()
+            post_id = int(post_id)
+            c.execute(
+                '''SELECT * FROM fanbox_master_post WHERE post_id = ?''',
+                (post_id,))
+            return c.fetchone()
+        except BaseException:
+            print('Error at selectPostByPostId():', str(sys.exc_info()))
+            print('failed')
+            raise
+        finally:
+            c.close()
+
+    def updatePostLastUpdateDate(self, post_id, updated_date):
+        try:
+            c = self.conn.cursor()
+            post_id = int(post_id)
+            c.execute(
+                '''UPDATE fanbox_master_post SET updated_date = ?
+                WHERE post_id = ?''',
+                (updated_date, post_id))
+            self.conn.commit()
+        except BaseException:
+            print('Error at updatePostLastUpdateDate():', str(sys.exc_info()))
+            print('failed')
+            raise
+        finally:
+            c.close()
+
+    def deleteFanboxPost(self, id, by):
+        id = int(id)
+        if by not in ["member_id", "post_id"]:
+            return
+        sql = f'''DELETE FROM fanbox_master_post WHERE {by} = ?'''
+
+        try:
+            c = self.conn.cursor()
+            c.execute(sql, (id,))
+            self.conn.commit()
+        except BaseException:
+            print('Error at deleteFanboxPost():', str(sys.exc_info()))
+            print('failed')
+            raise
+        finally:
+            c.close()
+
     def blacklistImage(self, memberId, ImageId):
         try:
             c = self.conn.cursor()
@@ -775,12 +889,16 @@ class PixivDBManager(object):
         print('12. Blacklist image by image_id')
         print('13. Show all deleted member')
         print('===============================================')
+        print('f1. Export FANBOX post list')
+        print('f2. Delete FANBOX download history by post_id')
+        print('f3. Delete FANBOX download history by member_id')
+        print('===============================================')
         print('c. Clean Up Database')
         print('i. Interactive Clean Up Database')
         print('p. Compact Database')
         print('r. Replace Root Path')
         print('x. Exit')
-        selection = input('Select one?').rstrip("\r")
+        selection = input('Select one? ').rstrip("\r")
         return selection
 
     def main(self):
@@ -859,6 +977,15 @@ class PixivDBManager(object):
                     self.blacklistImage(member_id, image_id)
                 elif selection == '13':
                     self.printMemberList(isDeleted=True)
+                elif selection == 'f1':
+                    filename = input('Filename? ').rstrip("\r")
+                    self.exportFanboxPostList(filename)
+                elif selection == 'f2':
+                    member_id = input('member_id? ').rstrip("\r")
+                    self.deleteFanboxPost(member_id, "post_id")
+                elif selection == 'f3':
+                    post_id = input('post_id? ').rstrip("\r")
+                    self.deleteFanboxPost(post_id, "member_id")
                 elif selection == 'c':
                     self.cleanUp()
                 elif selection == 'i':

--- a/PixivDBManager.py
+++ b/PixivDBManager.py
@@ -231,7 +231,7 @@ class PixivDBManager(object):
             c.close()
         print('done.')
 
-    def exportFanboxPostList(self, filename):
+    def exportFanboxPostList(self, filename, sep=","):
         print('Exporting FANBOX post list...', end=' ')
         try:
             c = self.conn.cursor()
@@ -239,14 +239,15 @@ class PixivDBManager(object):
                             ORDER BY member_id, post_id''')
             filename = filename + '.csv'
             writer = codecs.open(filename, 'wb', encoding='utf-8')
-            writer.write(
-                'member_id,post_id,title,fee_required,published_date,update_date,post_type,last_update_date\r\n')
+            columns = ['member_id','post_id','title','fee_required','published_date','update_date','post_type','last_update_date']
+            writer.write(sep.join(columns))
+            writer.write('\r\n')
             for row in c:
                 for string in row:
                     # Unicode write!!
                     data = str(string)
                     writer.write(data)
-                    writer.write(',')
+                    writer.write(sep)
                 writer.write('\r\n')
             writer.write('###END-OF-FILE###')
             writer.close()
@@ -979,7 +980,9 @@ class PixivDBManager(object):
                     self.printMemberList(isDeleted=True)
                 elif selection == 'f1':
                     filename = input('Filename? ').rstrip("\r")
-                    self.exportFanboxPostList(filename)
+                    sep = input('Separator? (1(default)=",", 2="\\t") ').rstrip("\r")
+                    sep = "\t" if sep=="2" else ","
+                    self.exportFanboxPostList(filename, sep)
                 elif selection == 'f2':
                     member_id = input('member_id? ').rstrip("\r")
                     self.deleteFanboxPost(member_id, "post_id")

--- a/PixivDBManager.py
+++ b/PixivDBManager.py
@@ -231,7 +231,7 @@ class PixivDBManager(object):
             c.close()
         print('done.')
 
-   def exportFanboxPostList(self, filename):
+    def exportFanboxPostList(self, filename):
         print('Exporting FANBOX post list...', end=' ')
         try:
             c = self.conn.cursor()
@@ -566,7 +566,7 @@ class PixivDBManager(object):
         finally:
             c.close()
 
-def insertPost(self, member_id, post_id, title, fee_required, published_date, post_type):
+    def insertPost(self, member_id, post_id, title, fee_required, published_date, post_type):
         try:
             c = self.conn.cursor()
             post_id = int(post_id)

--- a/PixivDBManager.py
+++ b/PixivDBManager.py
@@ -571,11 +571,11 @@ class PixivDBManager(object):
             c = self.conn.cursor()
             post_id = int(post_id)
             c.execute(
-                '''INSERT OR IGNORE INTO fanbox_master_post (member_id, post_id, last_update_date)
-                VALUES(?, ?, datetime('now'))''', (member_id, post_id))
+                '''INSERT OR IGNORE INTO fanbox_master_post (member_id, post_id) VALUES(?, ?)''',
+                (member_id, post_id))
             c.execute(
-                '''UPDATE fanbox_master_post SET title = ?, fee_required = ?, published_date = ?, post_type = ?
-                WHERE post_id = ?''',
+                '''UPDATE fanbox_master_post SET title = ?, fee_required = ?, published_date = ?, 
+                post_type = ?, last_update_date = datetime('now') WHERE post_id = ?''',
                 (title, fee_required, published_date, post_type, post_id))
             self.conn.commit()
         except BaseException:

--- a/PixivModelFanbox.py
+++ b/PixivModelFanbox.py
@@ -151,6 +151,10 @@ class FanboxPost(object):
         self.worksDateDateTime = datetime_z.parse_datetime(self.worksDate)
         self.updatedDate = jsPost["updatedDatetime"]
         self.updatedDateDatetime = datetime_z.parse_datetime(self.updatedDate)
+
+        if "feeRequired" in jsPost:
+            self.feeRequired = jsPost["feeRequired"]
+            
         # Issue #420
         if self._tzInfo is not None:
             self.worksDateDateTime = self.worksDateDateTime.astimezone(
@@ -248,9 +252,6 @@ class FanboxPost(object):
             self.body_text = u"{0}<br />{1}".format(
                              self.body_text,
                              self.getEmbedData(jsPost["body"]["video"], jsPost))
-
-        if "feeRequired" in jsPost:
-            self.feeRequired = jsPost["feeRequired"]
 
     def getEmbedData(self, embedData, jsPost):
         if not os.path.exists("content_provider.json"):

--- a/PixivModelFanbox.py
+++ b/PixivModelFanbox.py
@@ -6,46 +6,55 @@ import os
 import demjson
 from bs4 import BeautifulSoup
 
-import datetime_z
 import PixivHelper
+import datetime_z
 from PixivException import PixivException
 
 
-class Fanbox(object):
-    supportedArtist = None
+class FanboxArtist(object):
+    artistId = 0
+    creatorId = ""
+    nextUrl = None
+    hasNextPage = False
+    _tzInfo = None
+    # require additional API call
+    artistName = ""
+    artistToken = ""
 
-    def __init__(self, page):
+    SUPPORTED = 0
+    FOLLOWED = 1
+
+    @classmethod
+    def parseArtists(cls, page, tzInfo=None):
+        artists = list()
         js = demjson.decode(page)
 
         if "error" in js and js["error"]:
             raise PixivException("Error when requesting Fanbox", 9999, page)
 
         if "body" in js and js["body"] is not None:
-            self.parseSupportedArtists(js["body"])
+            js_body = js["body"]
+            if "supportingPlans" in js["body"]:
+                js_body = js_body["supportingPlans"]
+            for creator in js_body:
+                artists.append(
+                    FanboxArtist(creator["user"]["userId"],
+                                 creator["user"]["name"],
+                                 creator["creatorId"],
+                                 tzInfo=tzInfo
+                                 ))
+        return artists
 
-    def parseSupportedArtists(self, js_body):
-        self.supportedArtist = list()
-        # Fix #495
-        if "supportingPlans" in js_body:
-            js_body = js_body["supportingPlans"]
-        for creator in js_body:
-            self.supportedArtist.append(int(creator["user"]["userId"]))
-
-
-class FanboxArtist(object):
-    artistId = 0
-    posts = None
-    nextUrl = None
-    hasNextPage = False
-    _tzInfo = None
-
-    # require additional API call
-    artistName = ""
-    artistToken = ""
-
-    def __init__(self, artist_id, page, tzInfo=None):
+    def __init__(self, artist_id, artist_name, creator_id, tzInfo=None):
         self.artistId = int(artist_id)
+        self.artistName = artist_name
+        self.creatorId = creator_id
         self._tzInfo = tzInfo
+
+    def __str__(self):
+        return f"({self.artistId}, {self.creatorId}, {self.artistName})"
+
+    def parsePosts(self, page):
         js = demjson.decode(page)
 
         if "error" in js and js["error"]:
@@ -53,32 +62,33 @@ class FanboxArtist(object):
                 "Error when requesting Fanbox artist: {0}".format(self.artistId), 9999, page)
 
         if js["body"] is not None:
-            self.parsePosts(js["body"])
+            js_body = js["body"]
 
-    def parsePosts(self, js_body):
-        self.posts = list()
+            posts = list()
 
-        if "creator" in js_body:
-            self.artistName = js_body["creator"]["user"]["name"]
+            if "creator" in js_body:
+                self.artistName = js_body["creator"]["user"]["name"]
 
-        if "post" in js_body:
-            # new api
-            post_root = js_body["post"]
-        else:
-            # https://www.pixiv.net/ajax/fanbox/post?postId={0}
-            # or old api
-            post_root = js_body
+            if "post" in js_body:
+                # new api
+                post_root = js_body["post"]
+            else:
+                # https://www.pixiv.net/ajax/fanbox/post?postId={0}
+                # or old api
+                post_root = js_body
 
-        for jsPost in post_root["items"]:
-            post_id = int(jsPost["id"])
-            post = FanboxPost(post_id, self, jsPost, tzInfo=self._tzInfo)
-            self.posts.append(post)
-            # sanity check
-            assert (self.artistId == int(jsPost["user"]["userId"])), "Different user id from constructor!"
+            for jsPost in post_root["items"]:
+                post_id = int(jsPost["id"])
+                post = FanboxPost(post_id, self, jsPost, tzInfo=self._tzInfo)
+                posts.append(post)
+                # sanity check
+                assert (self.artistId == int(jsPost["user"]["userId"])), "Different user id from constructor!"
 
-        self.nextUrl = post_root["nextUrl"]
-        if self.nextUrl is not None and len(self.nextUrl) > 0:
-            self.hasNextPage = True
+            self.nextUrl = post_root["nextUrl"]
+            if self.nextUrl is not None and len(self.nextUrl) > 0:
+                self.hasNextPage = True
+
+            return posts
 
 
 class FanboxPost(object):
@@ -154,13 +164,12 @@ class FanboxPost(object):
 
         if "feeRequired" in jsPost:
             self.feeRequired = jsPost["feeRequired"]
-            
+
         # Issue #420
         if self._tzInfo is not None:
             self.worksDateDateTime = self.worksDateDateTime.astimezone(
                 self._tzInfo)
 
-                                                        
         self.type = jsPost["type"]
         if self.type not in FanboxPost._supportedType:
             raise PixivException("Unsupported post type = {0} for post = {1}".format(
@@ -228,30 +237,30 @@ class FanboxPost(object):
                 elif block["type"] == "image":
                     imageId = block["imageId"]
                     self.body_text = u"{0}<br /><a href='{1}'><img src='{2}'/></a>".format(
-                                     self.body_text,
-                                     jsPost["body"]["imageMap"][imageId]["originalUrl"],
-                                     jsPost["body"]["imageMap"][imageId]["thumbnailUrl"])
+                        self.body_text,
+                        jsPost["body"]["imageMap"][imageId]["originalUrl"],
+                        jsPost["body"]["imageMap"][imageId]["thumbnailUrl"])
                     self.try_add(jsPost["body"]["imageMap"][imageId]["originalUrl"], self.images)
                     self.try_add(jsPost["body"]["imageMap"][imageId]["originalUrl"], self.embeddedFiles)
                 elif block["type"] == "file":
                     fileId = block["fileId"]
                     self.body_text = u"{0}<br /><a href='{1}'>{2}</a>".format(
-                                     self.body_text,
-                                     jsPost["body"]["fileMap"][fileId]["url"],
-                                     jsPost["body"]["fileMap"][fileId]["name"])
+                        self.body_text,
+                        jsPost["body"]["fileMap"][fileId]["url"],
+                        jsPost["body"]["fileMap"][fileId]["name"])
                     self.try_add(jsPost["body"]["fileMap"][fileId]["url"], self.images)
                     self.try_add(jsPost["body"]["fileMap"][fileId]["url"], self.embeddedFiles)
                 elif block["type"] == "embed":  # Implement #470
                     embedId = block["embedId"]
                     self.body_text = u"{0}<br />{1}".format(
-                                     self.body_text,
-                                     self.getEmbedData(jsPost["body"]["embedMap"][embedId], jsPost))
+                        self.body_text,
+                        self.getEmbedData(jsPost["body"]["embedMap"][embedId], jsPost))
 
         # Issue #476
         if "video" in jsPost["body"]:
             self.body_text = u"{0}<br />{1}".format(
-                             self.body_text,
-                             self.getEmbedData(jsPost["body"]["video"], jsPost))
+                self.body_text,
+                self.getEmbedData(jsPost["body"]["video"], jsPost))
 
     def getEmbedData(self, embedData, jsPost):
         if not os.path.exists("content_provider.json"):

--- a/PixivModelFanbox.py
+++ b/PixivModelFanbox.py
@@ -87,7 +87,8 @@ class FanboxPost(object):
     coverImageUrl = ""
     worksDate = ""
     worksDateDateTime = None
-    updatedDatetime = ""
+    updatedDate = ""
+    updatedDateDatetime = None
     # image|text|file|article|video|entry
     _supportedType = ["image", "text", "file", "article", "video", "entry"]
     type = ""
@@ -96,14 +97,14 @@ class FanboxPost(object):
     likeCount = 0
     parent = None
     is_restricted = False
-
+    feeRequired = 0
     # compatibility
     imageMode = ""
     imageCount = 0
     _tzInfo = None
 
     linkToFile = None
-    
+
     # not implemented
     worksResolution = ""
     worksTools = ""
@@ -121,9 +122,9 @@ class FanboxPost(object):
         self.imageId = int(post_id)
         self.parent = parent
         self._tzInfo = tzInfo
-        
+
         self.linkToFile = dict()
-        
+
         self.parsePost(page)
 
         if not self.is_restricted:
@@ -148,12 +149,14 @@ class FanboxPost(object):
 
         self.worksDate = jsPost["publishedDatetime"]
         self.worksDateDateTime = datetime_z.parse_datetime(self.worksDate)
+        self.updatedDate = jsPost["updatedDatetime"]
+        self.updatedDateDatetime = datetime_z.parse_datetime(self.updatedDate)
         # Issue #420
         if self._tzInfo is not None:
             self.worksDateDateTime = self.worksDateDateTime.astimezone(
                 self._tzInfo)
 
-        self.updatedDatetime = jsPost["updatedDatetime"]
+                                                        
         self.type = jsPost["type"]
         if self.type not in FanboxPost._supportedType:
             raise PixivException("Unsupported post type = {0} for post = {1}".format(
@@ -246,6 +249,9 @@ class FanboxPost(object):
                              self.body_text,
                              self.getEmbedData(jsPost["body"]["video"], jsPost))
 
+        if "feeRequired" in jsPost:
+            self.feeRequired = jsPost["feeRequired"]
+
     def getEmbedData(self, embedData, jsPost):
         if not os.path.exists("content_provider.json"):
             raise PixivException("Missing content_provider.json, please redownload application!",
@@ -295,6 +301,13 @@ class FanboxPost(object):
             return
         if item not in list_data:
             list_data.append(item)
+
+    def printPost(self):
+        print("Post  = {0}".format(self.imageId))
+        print("Title = {0}".format(self.imageTitle))
+        print("Type  = {0}".format(self.type))
+        print("Created Date  = {0}".format(self.worksDate))
+        print("Is Restricted = {0}".format(self.is_restricted))
 
     def WriteInfo(self, filename):
         info = None

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1516,7 +1516,7 @@ def menu():
     print('f1. Download from supported artists (FANBOX)')
     print('f2. Download by artist id (FANBOX)')
     print('f3. Download by post id (FANBOX)')
-    print('f3. Download from followed artists (FANBOX)')
+    print('f4. Download from followed artists (FANBOX)')
     print('------------------------')
     print('d. Manage database')
     print('e. Export online bookmark')

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1516,6 +1516,7 @@ def menu():
     print('f1. Download from supported artists (FANBOX)')
     print('f2. Download by artist id (FANBOX)')
     print('f3. Download by post id (FANBOX)')
+    print('f3. Download from followed artists (FANBOX)')
     print('------------------------')
     print('d. Manage database')
     print('e. Export online bookmark')

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1921,7 +1921,6 @@ def menu_fanbox_download_from_artist(op_is_valid, via, args):
     elif via == PixivModelFanbox.FanboxArtist.FOLLOWED:
         via_type = "followed"
 
-                                                             
     __log__.info(f'Download FANBOX {via_type.capitalize()} Artists mode.')
     end_page = 0
 
@@ -1935,28 +1934,8 @@ def menu_fanbox_download_from_artist(op_is_valid, via, args):
     if not(fanbox_login):
         __log__.info("FANBOX login cookie string invalid, please update in config.ini")
         return
-                                                                                                                                                               
-                                 
 
     artists = __br__.fanboxGetUsers(via)
-                    
-            
-                                                    
-                                     
-                                                                                                                                                                                          
-
-
-                                                             
-                                                          
-                
-
-                                     
-                               
-         
-                                                         
-                                
-
-                                            
     if len(artists) == 0:
         PixivHelper.print_and_log("info", f"No {via_type} artist!")
         return
@@ -2537,6 +2516,9 @@ def main():
             __log__.info(msg)
 
         result = doLogin(password, username)
+        fanbox_login = __br__.fanboxLoginUsingCookie()
+        if not (fanbox_login):
+            __log__.info("FANBOX login cookie string invalid, please update in config.ini")
 
         if result:
             np_is_valid, op_is_valid, selection = main_loop(ewd, op_is_valid, selection, np_is_valid, args)

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -2123,7 +2123,7 @@ def menu_fanbox_download_by_artist_or_creator_id(op_is_valid, args):
     id = ''
 
     if op_is_valid and len(args) > 0:
-        id = str(int(args[0]))
+        id = args[0]
         if len(args) > 1:
             end_page = args[1]
     else:

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1938,6 +1938,31 @@ def menu_fanbox_download_supported_artist(op_is_valid, args):
             PixivHelper.print_and_log("error", "Error processing FANBOX Artist: {0} ==> {1}".format(artist_id, pex.message))
 
 
+def menu_fanbox_download_followed_artists(op_is_valid, args):
+    __log__.info('Download FANBOX Followed Artists mode.')
+    end_page = 0
+
+    if op_is_valid and len(args) > 0:
+        end_page = int(args[0])
+    else:
+        end_page = input("Max Page = ").rstrip("\r") or 0
+        end_page = int(end_page)
+
+    result = __br__.fanboxGetFollowedUsers()
+    if len(result.supportedArtist) == 0:
+        PixivHelper.print_and_log("info", "No following artist!")
+        return
+    PixivHelper.print_and_log("info", "Found {0} followed artist(s)".format(len(result.supportedArtist)))
+    print(result.supportedArtist)
+
+    for artist_id in result.supportedArtist:
+        # Issue #567
+        try:
+            processFanboxArtist(artist_id, end_page)
+        except PixivException as pex:
+            PixivHelper.print_and_log("error", "Error processing FANBOX Artist: {0} ==> {1}".format(artist_id, pex.message))
+
+
 def menu_fanbox_download_by_post_id(op_is_valid, args):
     __log__.info('Download FANBOX by post id mode.')
     if op_is_valid and len(args) > 0:
@@ -2137,7 +2162,7 @@ def set_console_title(title=''):
 
 def setup_option_parser():
     global __valid_options
-    __valid_options = ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', 'f1', 'f2', 'f3', 'd', 'e', 'm')
+    __valid_options = ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', 'f1', 'f2', 'f3', 'f4', 'd', 'e', 'm')
     parser = OptionParser()
     parser.add_option('-s', '--startaction', dest='startaction',
                       help='''Action you want to load your program with:
@@ -2156,6 +2181,7 @@ def setup_option_parser():
 f1 - Download from supported artists (FANBOX)
 f2 - Download by artist id (FANBOX)
 f3 - Download by post id (FANBOX)
+f4 - Download from following artists (FANBOX)
  e - Export online bookmark
  m - Export online user bookmark
  d - Manage database''')
@@ -2238,6 +2264,8 @@ def main_loop(ewd, op_is_valid, selection, np_is_valid_local, args):
                 menu_fanbox_download_by_artist_id(op_is_valid, args)
             elif selection == 'f3':
                 menu_fanbox_download_by_post_id(op_is_valid, args)
+            elif selection == 'f4':
+                menu_fanbox_download_followed_artists(op_is_valid, args)
             # END PIXIV FANBOX
             elif selection == '-all':
                 if not np_is_valid_local:

--- a/test/Fanbox_supported_artist.json
+++ b/test/Fanbox_supported_artist.json
@@ -1,732 +1,731 @@
 {
-	"body": [
-		{
-			"id": "10930",
-			"title": "「好きな作家さんの同人誌をコレで買いなさい」または「画材の足しにして」",
-			"fee": 500,
-			"description": "月に一冊同人誌をおごってくれる素敵な人（←　好き♪\r\nまたは画材代を支援してお絵かきを応援してくれる方（←　好き♪\r\n限定公開のHな絵が見れる。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/10930/cover/PZ07QSsQSzOe4sJ0y56GEKNK.jpeg",
-			"user": {
-				"userId": "4820",
-				"name": "猫耳　花音",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/4820/icon/AvB7gFWmDvmgaeDFB48XHXfA.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+	"body": [{
+		"id": "10930",
+		"title": "「好きな作家さんの同人誌をコレで買いなさい」または「画材の足しにして」",
+		"fee": 500,
+		"description": "月に一冊同人誌をおごってくれる素敵な人（←　好き♪\r\nまたは画材代を支援してお絵かきを応援してくれる方（←　好き♪\r\n限定公開のHな絵が見れる。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/10930/cover/PZ07QSsQSzOe4sJ0y56GEKNK.jpeg",
+		"user": {
+			"userId": "4820",
+			"name": "猫耳　花音",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/4820/icon/AvB7gFWmDvmgaeDFB48XHXfA.jpeg"
 		},
-		{
-			"id": "50037",
-			"title": "500円",
-			"fee": 500,
-			"description": "投稿から6か月たったものはこちらに移動します。それとたまに500円限定の差分イラストを上げます。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/50037/cover/QfOXflbPPvxdR4E59GMnvLG3.jpeg",
-			"user": {
-				"userId": "7968",
-				"name": "伊藤達哉",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/7968/icon/3TXFEP8ELMnaLhkS60eqEDH6.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "50037",
+		"title": "500円",
+		"fee": 500,
+		"description": "投稿から6か月たったものはこちらに移動します。それとたまに500円限定の差分イラストを上げます。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/50037/cover/QfOXflbPPvxdR4E59GMnvLG3.jpeg",
+		"user": {
+			"userId": "7968",
+			"name": "伊藤達哉",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/7968/icon/3TXFEP8ELMnaLhkS60eqEDH6.jpeg"
 		},
-		{
-			"id": "38114",
-			"title": "ラムネプラン",
-			"fee": 100,
-			"description": "双木こじろにブドウ糖90%のラムネを食べさせるプランです。\r\nペンタブの芯や絵の資料の資金になることもあります。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/38114/cover/8AE1M6JTYutnFLfUeRsE0ofL.jpeg",
-			"user": {
-				"userId": "11443",
-				"name": "双木こじろ",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/11443/icon/quTymdIRXnfjFKEhlDVUM9ba.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "38114",
+		"title": "ラムネプラン",
+		"fee": 100,
+		"description": "双木こじろにブドウ糖90%のラムネを食べさせるプランです。\r\nペンタブの芯や絵の資料の資金になることもあります。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/38114/cover/8AE1M6JTYutnFLfUeRsE0ofL.jpeg",
+		"user": {
+			"userId": "11443",
+			"name": "双木こじろ",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/11443/icon/quTymdIRXnfjFKEhlDVUM9ba.jpeg"
 		},
-		{
-			"id": "15330",
-			"title": "調教支援：ピンクローター",
-			"fee": 250,
-			"description": "あかいしの調教にピンクローターの力が加わり\nあかいしの戦闘力がちょっとだけ高まります。",
-			"coverImageUrl": null,
-			"user": {
-				"userId": "91029",
-				"name": "あかいししろいし",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/91029/icon/88cadMWRtY4Rak2TYCO2nxra.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "15330",
+		"title": "調教支援：ピンクローター",
+		"fee": 250,
+		"description": "あかいしの調教にピンクローターの力が加わり\nあかいしの戦闘力がちょっとだけ高まります。",
+		"coverImageUrl": null,
+		"user": {
+			"userId": "91029",
+			"name": "あかいししろいし",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/91029/icon/88cadMWRtY4Rak2TYCO2nxra.jpeg"
 		},
-		{
-			"id": "23834",
-			"title": "ドリンクタイム",
-			"fee": 200,
-			"description": "赤い牛とか怪物力を買います。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/23834/cover/VLnjWLNnz8n3pFfm6YyZPTu1.jpeg",
-			"user": {
-				"userId": "151050",
-				"name": "わっちー",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/151050/icon/530GbYo4o0fCjt6tiUHT6RCt.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "23834",
+		"title": "ドリンクタイム",
+		"fee": 200,
+		"description": "赤い牛とか怪物力を買います。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/23834/cover/VLnjWLNnz8n3pFfm6YyZPTu1.jpeg",
+		"user": {
+			"userId": "151050",
+			"name": "わっちー",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/151050/icon/530GbYo4o0fCjt6tiUHT6RCt.jpeg"
 		},
-		{
-			"id": "22444",
-			"title": "サポートA",
-			"fee": 200,
-			"description": "通常投稿作品のR18バージョンや高解像度版、長い動画(うごくイラスト)が閲覧できます。支援金はソフトウエア購入、使用代金に使わせていただきます。\r\nYou can view R18 version of the contribution work, high resolution version, long video (Ugoku_illustrations). I will use your donations for software purchase and usage fee.",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/22444/cover/CXjsJ3oeXNFcy2iYlGXhm26N.jpeg",
-			"user": {
-				"userId": "195364",
-				"name": "tooo",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/195364/icon/nbyDJpVBz9jMsBgN9lafj0eP.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "22444",
+		"title": "サポートA",
+		"fee": 200,
+		"description": "通常投稿作品のR18バージョンや高解像度版、長い動画(うごくイラスト)が閲覧できます。支援金はソフトウエア購入、使用代金に使わせていただきます。\r\nYou can view R18 version of the contribution work, high resolution version, long video (Ugoku_illustrations). I will use your donations for software purchase and usage fee.",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/22444/cover/CXjsJ3oeXNFcy2iYlGXhm26N.jpeg",
+		"user": {
+			"userId": "195364",
+			"name": "tooo",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/195364/icon/nbyDJpVBz9jMsBgN9lafj0eP.jpeg"
 		},
-		{
-			"id": "7329",
-			"title": "ストパンエロ絵置き場（ダウンロード用）",
-			"fee": 250,
-			"description": "趣味で描いてPIXIVに上げたエロ絵や、その差分を投稿する場所。無料のところとほとんど変わらないから特に有料プランに入る必要はないけど、ダウンロードしやすいよう差分ごとファイルにまとめるよ（断面図や拡大図付き差分ファイル追加するかも）。\n後、以前描いたエロ絵のリメイクと差分をのっけるかも。最低月１更新。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/7329/cover/n91lwh6eAjcV7w2MRah4Nmao.jpeg",
-			"user": {
-				"userId": "226267",
-				"name": "髭侍",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/226267/icon/sxsTDCwrUQwBj6uRuWKMAzj4.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "7329",
+		"title": "ストパンエロ絵置き場（ダウンロード用）",
+		"fee": 250,
+		"description": "趣味で描いてPIXIVに上げたエロ絵や、その差分を投稿する場所。無料のところとほとんど変わらないから特に有料プランに入る必要はないけど、ダウンロードしやすいよう差分ごとファイルにまとめるよ（断面図や拡大図付き差分ファイル追加するかも）。\n後、以前描いたエロ絵のリメイクと差分をのっけるかも。最低月１更新。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/7329/cover/n91lwh6eAjcV7w2MRah4Nmao.jpeg",
+		"user": {
+			"userId": "226267",
+			"name": "髭侍",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/226267/icon/sxsTDCwrUQwBj6uRuWKMAzj4.jpeg"
 		},
-		{
-			"id": "57409",
-			"title": "もっとお絵描き頑張ってね☆プラン",
-			"fee": 500,
-			"description": "特になにもありませんが、日頃のお絵描きをもっと頑張る気力が更に沸きます",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/57409/cover/cI6qBbgItDvHrHPOyx66gpS0.jpeg",
-			"user": {
-				"userId": "376735",
-				"name": "るいるい",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/376735/icon/GGTIP2kFojXxeHJE7cEcRva6.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "57409",
+		"title": "もっとお絵描き頑張ってね☆プラン",
+		"fee": 500,
+		"description": "特になにもありませんが、日頃のお絵描きをもっと頑張る気力が更に沸きます",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/57409/cover/cI6qBbgItDvHrHPOyx66gpS0.jpeg",
+		"user": {
+			"userId": "376735",
+			"name": "るいるい",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/376735/icon/GGTIP2kFojXxeHJE7cEcRva6.jpeg"
 		},
-		{
-			"id": "19421",
-			"title": " Just a pay some Rewards page,No payment content",
-			"fee": 100,
-			"description": "何もない！！！！！！！！！！！！！！！！！！！！\r\n只是一個打賞的頁面。\r\n沒有任何付費内容\r\nJust a paying some Tips/Reward's page.\r\nHas no payment content\r\nただ、いくつかのヒントのページを支払います。(machine)\r\n\r\n",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/19421/cover/Dr7lHtCssipQnCNLNFIMIgAz.jpeg",
-			"user": {
-				"userId": "634336",
-				"name": "喵行燈[pass]",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/634336/icon/YLe6B5XLbiWtXHiWVzn0WkJx.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "19421",
+		"title": " Just a pay some Rewards page,No payment content",
+		"fee": 100,
+		"description": "何もない！！！！！！！！！！！！！！！！！！！！\r\n只是一個打賞的頁面。\r\n沒有任何付費内容\r\nJust a paying some Tips/Reward's page.\r\nHas no payment content\r\nただ、いくつかのヒントのページを支払います。(machine)\r\n\r\n",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/19421/cover/Dr7lHtCssipQnCNLNFIMIgAz.jpeg",
+		"user": {
+			"userId": "634336",
+			"name": "喵行燈[pass]",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/634336/icon/YLe6B5XLbiWtXHiWVzn0WkJx.jpeg"
 		},
-		{
-			"id": "64153",
-			"title": "ラーメンプラン",
-			"fee": 500,
-			"description": "みかぐらがお昼ご飯にラーメンを食べられます。\npixivに投稿したイラストの高解像度版や未公開差分、限定公開イラストなど",
-			"coverImageUrl": null,
-			"user": {
-				"userId": "642151",
-				"name": "みかぐら",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/642151/icon/fpHzu25VUYF3y5y5kFBjMdjV.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "64153",
+		"title": "ラーメンプラン",
+		"fee": 500,
+		"description": "みかぐらがお昼ご飯にラーメンを食べられます。\npixivに投稿したイラストの高解像度版や未公開差分、限定公開イラストなど",
+		"coverImageUrl": null,
+		"user": {
+			"userId": "642151",
+			"name": "みかぐら",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/642151/icon/fpHzu25VUYF3y5y5kFBjMdjV.jpeg"
 		},
-		{
-			"id": "25985",
-			"title": "やる気スイッチ",
-			"fee": 300,
-			"description": "落書き・ラフ・高画質版が閲覧できます",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/25985/cover/jMlX9E92sLdTUyFjS9F30tYD.jpeg",
-			"user": {
-				"userId": "1030278",
-				"name": "とりあっとぐぬぬ",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1030278/icon/lhS7qcfvYdo217eQunGlejQ1.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "25985",
+		"title": "やる気スイッチ",
+		"fee": 300,
+		"description": "落書き・ラフ・高画質版が閲覧できます",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/25985/cover/jMlX9E92sLdTUyFjS9F30tYD.jpeg",
+		"user": {
+			"userId": "1030278",
+			"name": "とりあっとぐぬぬ",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1030278/icon/lhS7qcfvYdo217eQunGlejQ1.jpeg"
 		},
-		{
-			"id": "43196",
-			"title": "エキスパートエディション",
-			"fee": 500,
-			"description": "マンガ形式の差分イラストなどを考えています。\r\n制作者は煮干しつけ麺が食べられます。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/43196/cover/Xil20skVpr2sWsWVzZ1alOtt.jpeg",
-			"user": {
-				"userId": "1046936",
-				"name": "アブトマト",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1046936/icon/0iBaWBh8JeNE7NHtXJnVnU3R.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "43196",
+		"title": "エキスパートエディション",
+		"fee": 500,
+		"description": "マンガ形式の差分イラストなどを考えています。\r\n制作者は煮干しつけ麺が食べられます。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/43196/cover/Xil20skVpr2sWsWVzZ1alOtt.jpeg",
+		"user": {
+			"userId": "1046936",
+			"name": "アブトマト",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1046936/icon/0iBaWBh8JeNE7NHtXJnVnU3R.jpeg"
 		},
-		{
-			"id": "29051",
-			"title": "１８禁っぽいの",
-			"fee": 200,
-			"description": "スク水娘を描く上でスク水をまだ着ていないスク水少女とか見れます。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/29051/cover/njuKDrsR3Ls7I9c4hoSHj1ZB.jpeg",
-			"user": {
-				"userId": "1094478",
-				"name": "ろひつか",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1094478/icon/PQCsaGKcNV59I2ilU3sFCIZY.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "29051",
+		"title": "１８禁っぽいの",
+		"fee": 200,
+		"description": "スク水娘を描く上でスク水をまだ着ていないスク水少女とか見れます。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/29051/cover/njuKDrsR3Ls7I9c4hoSHj1ZB.jpeg",
+		"user": {
+			"userId": "1094478",
+			"name": "ろひつか",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1094478/icon/PQCsaGKcNV59I2ilU3sFCIZY.jpeg"
 		},
-		{
-			"id": "77592",
-			"title": "500",
-			"fee": 500,
-			"description": "10月はPatreonの新作を中心に過去作品など投稿したいと思います。スケッチ、完成絵、モノクロなど含まれます。\nIn Octorber we will post new works mainly with past works of Patreon. Includes sketches, full shade, and monochrome.\n",
-			"coverImageUrl": null,
-			"user": {
-				"userId": "1131293",
-				"name": "Tenebre Publisher (CoCo)",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1131293/icon/9eY25HnINd09fbu9biGhbsTI.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "77592",
+		"title": "500",
+		"fee": 500,
+		"description": "10月はPatreonの新作を中心に過去作品など投稿したいと思います。スケッチ、完成絵、モノクロなど含まれます。\nIn Octorber we will post new works mainly with past works of Patreon. Includes sketches, full shade, and monochrome.\n",
+		"coverImageUrl": null,
+		"user": {
+			"userId": "1131293",
+			"name": "Tenebre Publisher (CoCo)",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1131293/icon/9eY25HnINd09fbu9biGhbsTI.jpeg"
 		},
-		{
-			"id": "32339",
-			"title": "Plan 5",
-			"fee": 500,
-			"description": "PIXIV公開画の差分画や、支援者様限定画など全てをご覧になれます。",
-			"coverImageUrl": null,
-			"user": {
-				"userId": "1149958",
-				"name": "カミマキ ツカミ",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1149958/icon/6waWjowBUvtCKTEXti9Qw1Ql.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "32339",
+		"title": "Plan 5",
+		"fee": 500,
+		"description": "PIXIV公開画の差分画や、支援者様限定画など全てをご覧になれます。",
+		"coverImageUrl": null,
+		"user": {
+			"userId": "1149958",
+			"name": "カミマキ ツカミ",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1149958/icon/6waWjowBUvtCKTEXti9Qw1Ql.jpeg"
 		},
-		{
-			"id": "26356",
-			"title": "えびみそプラン",
-			"fee": 500,
-			"description": "18禁や特殊な性癖のイラストや短編の漫画を不定期に掲載していきたいです。ご支援いただけたらうれしいです。※ファンティアと投稿内容は同じです。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/26356/cover/ikiDiVF4usteRczoPkeH6Bn3.jpeg",
-			"user": {
-				"userId": "1276620",
-				"name": "いしみそ",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1276620/icon/wqNjXH7IaRvWLxjcbmSuTc1h.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "26356",
+		"title": "えびみそプラン",
+		"fee": 500,
+		"description": "18禁や特殊な性癖のイラストや短編の漫画を不定期に掲載していきたいです。ご支援いただけたらうれしいです。※ファンティアと投稿内容は同じです。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/26356/cover/ikiDiVF4usteRczoPkeH6Bn3.jpeg",
+		"user": {
+			"userId": "1276620",
+			"name": "いしみそ",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1276620/icon/wqNjXH7IaRvWLxjcbmSuTc1h.jpeg"
 		},
-		{
-			"id": "51601",
-			"title": "実績解除：戦友",
-			"fee": 150,
-			"description": "ベア猫の作戦行動を援護した。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/51601/cover/jg1YBTxD9cP3ruDvItU2uSzl.jpeg",
-			"user": {
-				"userId": "1368840",
-				"name": "ベア猫（遺伝子組み換えでない）",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1368840/icon/TcKSISCf2q5TTASuxlBOmmnn.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "51601",
+		"title": "実績解除：戦友",
+		"fee": 150,
+		"description": "ベア猫の作戦行動を援護した。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/51601/cover/jg1YBTxD9cP3ruDvItU2uSzl.jpeg",
+		"user": {
+			"userId": "1368840",
+			"name": "ベア猫（遺伝子組み換えでない）",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1368840/icon/TcKSISCf2q5TTASuxlBOmmnn.jpeg"
 		},
-		{
-			"id": "79834",
-			"title": "投げ銭（小3）",
-			"fee": 300,
-			"description": "女子小学3年生向けのプランです。\n山田がお弁当を1つ食べられます。",
-			"coverImageUrl": null,
-			"user": {
-				"userId": "1769484",
-				"name": "山田の性活が第一",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1769484/icon/IXZrfHhSuDIGVTDihj0DLqYu.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "79834",
+		"title": "投げ銭（小3）",
+		"fee": 300,
+		"description": "女子小学3年生向けのプランです。\n山田がお弁当を1つ食べられます。",
+		"coverImageUrl": null,
+		"user": {
+			"userId": "1769484",
+			"name": "山田の性活が第一",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1769484/icon/IXZrfHhSuDIGVTDihj0DLqYu.jpeg"
 		},
-		{
-			"id": "71632",
-			"title": "圧力",
-			"fee": 100,
-			"description": "創作活動を促す圧力がかかります。\r\n稀にイラストの原寸公開やラフ投稿があるかもしれません。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/71632/cover/l2SLNfM0ZvdwsCIHKhQQal6m.jpeg",
-			"user": {
-				"userId": "1831980",
-				"name": "pxkanif + huyusilver",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1831980/icon/0iYlM8p0zO477c7Tj2wW91ih.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "71632",
+		"title": "圧力",
+		"fee": 100,
+		"description": "創作活動を促す圧力がかかります。\r\n稀にイラストの原寸公開やラフ投稿があるかもしれません。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/71632/cover/l2SLNfM0ZvdwsCIHKhQQal6m.jpeg",
+		"user": {
+			"userId": "1831980",
+			"name": "pxkanif + huyusilver",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/1831980/icon/0iYlM8p0zO477c7Tj2wW91ih.jpeg"
 		},
-		{
-			"id": "54568",
-			"title": "一筆に紅茶一杯のプラン",
-			"fee": 498,
-			"description": "エッチな絵の原動力に、一杯の紅茶を支援頂きたいプランです\npixivに投稿している絵の高解像度版や差分などを提供させていただきます\nあなたのご支援とお心に大変感謝いたします ",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/54568/cover/f2v7DFOuH0pDEM94Kqa5wVLL.jpeg",
-			"user": {
-				"userId": "2221925",
-				"name": "真綿",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/2221925/icon/TnrEk24ySSCTbgZxoiBCvrMU.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "54568",
+		"title": "一筆に紅茶一杯のプラン",
+		"fee": 498,
+		"description": "エッチな絵の原動力に、一杯の紅茶を支援頂きたいプランです\npixivに投稿している絵の高解像度版や差分などを提供させていただきます\nあなたのご支援とお心に大変感謝いたします ",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/54568/cover/f2v7DFOuH0pDEM94Kqa5wVLL.jpeg",
+		"user": {
+			"userId": "2221925",
+			"name": "真綿",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/2221925/icon/TnrEk24ySSCTbgZxoiBCvrMU.jpeg"
 		},
-		{
-			"id": "62985",
-			"title": "300",
-			"fee": 300,
-			"description": "",
-			"coverImageUrl": null,
-			"user": {
-				"userId": "2408551",
-				"name": "ぽこにゃん",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/2408551/icon/SkhA1alyqbhMNs07daiHAbdc.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "62985",
+		"title": "300",
+		"fee": 300,
+		"description": "",
+		"coverImageUrl": null,
+		"user": {
+			"userId": "2408551",
+			"name": "ぽこにゃん",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/2408551/icon/SkhA1alyqbhMNs07daiHAbdc.jpeg"
 		},
-		{
-			"id": "51378",
-			"title": "毎月緊縛プラン",
-			"fee": 200,
-			"description": "（毎月更新しましたら古いほうを削除する予定です。お早めに保存して頂きますようお願いいたします。）\r\nFanbox始めました！！試運転として、月額200円で、毎月独占でお縛りのオリジナル画像を一枚上げてきます！基本、話題な女の子(アニメ、ソシャゲー中心)で書こうと思います！どうぞよろしくお願いします！！",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/51378/cover/kKIN01S5y3jpV3zPyXWFi3e9.jpeg",
-			"user": {
-				"userId": "3452804",
-				"name": "HaneRu",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/3452804/icon/b4AWDuOCKPCsgxsdYYURLlSL.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "51378",
+		"title": "毎月緊縛プラン",
+		"fee": 200,
+		"description": "（毎月更新しましたら古いほうを削除する予定です。お早めに保存して頂きますようお願いいたします。）\r\nFanbox始めました！！試運転として、月額200円で、毎月独占でお縛りのオリジナル画像を一枚上げてきます！基本、話題な女の子(アニメ、ソシャゲー中心)で書こうと思います！どうぞよろしくお願いします！！",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/51378/cover/kKIN01S5y3jpV3zPyXWFi3e9.jpeg",
+		"user": {
+			"userId": "3452804",
+			"name": "HaneRu",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/3452804/icon/b4AWDuOCKPCsgxsdYYURLlSL.jpeg"
 		},
-		{
-			"id": "78034",
-			"title": "エネルギー注入プラン Patreon 300",
-			"fee": 300,
-			"description": "支援が多いほど早く描けます～（わがまま　\r\n不定期で未公開ラフを支援者だけに公開します",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/78034/cover/uaBHEnYIhTyAKaDBvVEN0ZAx.jpeg",
-			"user": {
-				"userId": "4417141",
-				"name": "クロニ",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/4417141/icon/hnNvWHyfFOXYGPl1vFTm2wKu.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "78034",
+		"title": "エネルギー注入プラン Patreon 300",
+		"fee": 300,
+		"description": "支援が多いほど早く描けます～（わがまま　\r\n不定期で未公開ラフを支援者だけに公開します",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/78034/cover/uaBHEnYIhTyAKaDBvVEN0ZAx.jpeg",
+		"user": {
+			"userId": "4417141",
+			"name": "クロニ",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/4417141/icon/hnNvWHyfFOXYGPl1vFTm2wKu.jpeg"
 		},
-		{
-			"id": "87526",
-			"title": "普通に応援",
-			"fee": 600,
-			"description": "普段のラフやイラストを観ることができます。\n気軽に応援プランより、月にもう一枚のスペシャルイラストを観ることがきるようになります。\nショットストーリーの１ー２ページを観ることができます。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/87526/cover/6R5J5c5FohoeZ3BZoAHUZOyv.jpeg",
-			"user": {
-				"userId": "4704179",
-				"name": "万天気像",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/4704179/icon/1HlyC5Axr3StL3XQUHZvpQDj.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "87526",
+		"title": "普通に応援",
+		"fee": 600,
+		"description": "普段のラフやイラストを観ることができます。\n気軽に応援プランより、月にもう一枚のスペシャルイラストを観ることがきるようになります。\nショットストーリーの１ー２ページを観ることができます。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/87526/cover/6R5J5c5FohoeZ3BZoAHUZOyv.jpeg",
+		"user": {
+			"userId": "4704179",
+			"name": "万天気像",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/4704179/icon/1HlyC5Axr3StL3XQUHZvpQDj.jpeg"
 		},
-		{
-			"id": "70032",
-			"title": "PSD元ファイルを取得",
-			"fee": 750,
-			"description": "可以得到作者本月新作的PSD原文件\n作者の今月新作のPSDファイルを入手できます。\nget the original PSD file that the author wrote this month.",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/70032/cover/WhaKe10PO8BWn7ploP688BW4.jpeg",
-			"user": {
-				"userId": "5165814",
-				"name": "神奇火鸡（Wonder Turkey）",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/5165814/icon/NzsxKESsUOsH2gkEn8kxCFl8.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "70032",
+		"title": "PSD元ファイルを取得",
+		"fee": 750,
+		"description": "可以得到作者本月新作的PSD原文件\n作者の今月新作のPSDファイルを入手できます。\nget the original PSD file that the author wrote this month.",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/70032/cover/WhaKe10PO8BWn7ploP688BW4.jpeg",
+		"user": {
+			"userId": "5165814",
+			"name": "神奇火鸡（Wonder Turkey）",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/5165814/icon/NzsxKESsUOsH2gkEn8kxCFl8.jpeg"
 		},
-		{
-			"id": "14795",
-			"title": "見放題プラン",
-			"fee": 300,
-			"description": "見放題プランです。",
-			"coverImageUrl": null,
-			"user": {
-				"userId": "5664611",
-				"name": "Θωθ",
-				"iconUrl": null
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "14795",
+		"title": "見放題プラン",
+		"fee": 300,
+		"description": "見放題プランです。",
+		"coverImageUrl": null,
+		"user": {
+			"userId": "5664611",
+			"name": "Θωθ",
+			"iconUrl": null
 		},
-		{
-			"id": "95835",
-			"title": "Previews of drawing in progress.",
-			"fee": 150,
-			"description": "Sketches with news and ideas of drawings I am currently working on. \r\nJist like in patreon. :3\r\nMight also post colored progress reports of larger projects.  ^^",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/95835/cover/s0tOyvCCcNXA2V24lAAwPcg7.jpeg",
-			"user": {
-				"userId": "5944252",
-				"name": "Hotel01",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/5944252/icon/R6Gu6354EmTMQO6NP97eDVdC.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "95835",
+		"title": "Previews of drawing in progress.",
+		"fee": 150,
+		"description": "Sketches with news and ideas of drawings I am currently working on. \r\nJist like in patreon. :3\r\nMight also post colored progress reports of larger projects.  ^^",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/95835/cover/s0tOyvCCcNXA2V24lAAwPcg7.jpeg",
+		"user": {
+			"userId": "5944252",
+			"name": "Hotel01",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/5944252/icon/R6Gu6354EmTMQO6NP97eDVdC.jpeg"
 		},
-		{
-			"id": "59121",
-			"title": "毎月一枚r18同人プラン",
-			"fee": 200,
-			"description": "月末で一枚以上のr18同人イラストを限定公開します！テーマは今期アニメや、ゲーム等、ネトラレ、陵辱等もあります！",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/59121/cover/kf5nD3JrXkjABocaaDgY9Mkb.jpeg",
-			"user": {
-				"userId": "6049901",
-				"name": "鬼針草",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/6049901/icon/SHqjwGwp3G3Ya7S3k6o4wfTf.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "59121",
+		"title": "毎月一枚r18同人プラン",
+		"fee": 200,
+		"description": "月末で一枚以上のr18同人イラストを限定公開します！テーマは今期アニメや、ゲーム等、ネトラレ、陵辱等もあります！",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/59121/cover/kf5nD3JrXkjABocaaDgY9Mkb.jpeg",
+		"user": {
+			"userId": "6049901",
+			"name": "鬼針草",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/6049901/icon/SHqjwGwp3G3Ya7S3k6o4wfTf.jpeg"
 		},
-		{
-			"id": "39309",
-			"title": "プラン500",
-			"fee": 500,
-			"description": "高解像度イラストを閲覧することができます。\r\nYou can see high resolution images.",
-			"coverImageUrl": null,
-			"user": {
-				"userId": "6357272",
-				"name": "ろるゐ紳士",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/6357272/icon/XKIw7maSfZV8xAvPHbvL6lnO.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "39309",
+		"title": "プラン500",
+		"fee": 500,
+		"description": "高解像度イラストを閲覧することができます。\r\nYou can see high resolution images.",
+		"coverImageUrl": null,
+		"user": {
+			"userId": "6357272",
+			"name": "ろるゐ紳士",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/6357272/icon/XKIw7maSfZV8xAvPHbvL6lnO.jpeg"
 		},
-		{
-			"id": "86864",
-			"title": "600円プラン",
-			"fee": 600,
-			"description": "いつも通り、ファンボックスがpatreonみたいに使います。\n不安定ですが、毎月１差分絵セット保証します、２セットが頑張ります。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/86864/cover/eOEV1YvAzynCfL1aYj08ptOG.jpeg",
-			"user": {
-				"userId": "6610818",
-				"name": "サーモン",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/6610818/icon/uXK2ehrKEL8prJwLx5qebuXF.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "86864",
+		"title": "600円プラン",
+		"fee": 600,
+		"description": "いつも通り、ファンボックスがpatreonみたいに使います。\n不安定ですが、毎月１差分絵セット保証します、２セットが頑張ります。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/86864/cover/eOEV1YvAzynCfL1aYj08ptOG.jpeg",
+		"user": {
+			"userId": "6610818",
+			"name": "サーモン",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/6610818/icon/uXK2ehrKEL8prJwLx5qebuXF.jpeg"
 		},
-		{
-			"id": "93775",
-			"title": "It helps me concentrate on my work.",
-			"fee": 200,
-			"description": "I will upload a private picture for the fan box once a month.",
-			"coverImageUrl": null,
-			"user": {
-				"userId": "10414967",
-				"name": "kkta",
-				"iconUrl": null
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "93775",
+		"title": "It helps me concentrate on my work.",
+		"fee": 200,
+		"description": "I will upload a private picture for the fan box once a month.",
+		"coverImageUrl": null,
+		"user": {
+			"userId": "10414967",
+			"name": "kkta",
+			"iconUrl": null
 		},
-		{
-			"id": "13242",
-			"title": "スタンダートプラン",
-			"fee": 500,
-			"description": "えっちな絵を見たい方のスタンダートなプランです。\r\nTwitterにはスケベすぎて載せられない支援者限定イラストやエロ差分、文字なし差分などを定期的に載せます。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/13242/cover/KqDzOeEmxS2pa78DiuHEGkbB.jpeg",
-			"user": {
-				"userId": "10594960",
-				"name": "弥猫うた",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/10594960/icon/xXk4UqYlTXuHaFN6QEdWWkE2.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "13242",
+		"title": "スタンダートプラン",
+		"fee": 500,
+		"description": "えっちな絵を見たい方のスタンダートなプランです。\r\nTwitterにはスケベすぎて載せられない支援者限定イラストやエロ差分、文字なし差分などを定期的に載せます。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/13242/cover/KqDzOeEmxS2pa78DiuHEGkbB.jpeg",
+		"user": {
+			"userId": "10594960",
+			"name": "弥猫うた",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/10594960/icon/xXk4UqYlTXuHaFN6QEdWWkE2.jpeg"
 		},
-		{
-			"id": "49868",
-			"title": "お賽銭箱",
-			"fee": 200,
-			"description": "pixiv、ツイッター等で上げてる絵の裸verなど上げたいと思います～",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/49868/cover/mZnXCfifwWTrsCxB7W92WGqk.jpeg",
-			"user": {
-				"userId": "11229342",
-				"name": "サインこす",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/11229342/icon/AIfY06L4CPM2WiadhfMlHViT.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "49868",
+		"title": "お賽銭箱",
+		"fee": 200,
+		"description": "pixiv、ツイッター等で上げてる絵の裸verなど上げたいと思います～",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/49868/cover/mZnXCfifwWTrsCxB7W92WGqk.jpeg",
+		"user": {
+			"userId": "11229342",
+			"name": "サインこす",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/11229342/icon/AIfY06L4CPM2WiadhfMlHViT.jpeg"
 		},
-		{
-			"id": "72698",
-			"title": "喜欢的话给个赞助吧…",
-			"fee": 200,
-			"description": "",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/72698/cover/clb46Zb6PrwAHjh17fOHMN3D.jpeg",
-			"user": {
-				"userId": "12016484",
-				"name": "HLL.ALSG99",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/12016484/icon/EaoIZnz0fP6xxkCQ4siTyd4o.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "72698",
+		"title": "喜欢的话给个赞助吧…",
+		"fee": 200,
+		"description": "",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/72698/cover/clb46Zb6PrwAHjh17fOHMN3D.jpeg",
+		"user": {
+			"userId": "12016484",
+			"name": "HLL.ALSG99",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/12016484/icon/EaoIZnz0fP6xxkCQ4siTyd4o.jpeg"
 		},
-		{
-			"id": "59173",
-			"title": "落書き",
-			"fee": 500,
-			"description": "ここで私の普段の落書きと受付のイラストの落書きを発表する。落書きほとんどは人体緊縛の姿についての絵です。そしてみんなと一緒にいい場面を構想したいと思います。\r\n我會在這裡發佈一些平時構想的草稿以及約稿的草圖，草圖大部分情況下是突然想到的能用在捆綁里的人體結構 我很樂意和大家一起想後面的構思之類的東西_(:з」∠)_",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/59173/cover/zjFQY2WTAs0bR6MNklWYXBlS.jpeg",
-			"user": {
-				"userId": "12063067",
-				"name": "臣訾",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/12063067/icon/ciyGaxmudPK7wsrqY0kDcwRj.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "59173",
+		"title": "落書き",
+		"fee": 500,
+		"description": "ここで私の普段の落書きと受付のイラストの落書きを発表する。落書きほとんどは人体緊縛の姿についての絵です。そしてみんなと一緒にいい場面を構想したいと思います。\r\n我會在這裡發佈一些平時構想的草稿以及約稿的草圖，草圖大部分情況下是突然想到的能用在捆綁里的人體結構 我很樂意和大家一起想後面的構思之類的東西_(:з」∠)_",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/59173/cover/zjFQY2WTAs0bR6MNklWYXBlS.jpeg",
+		"user": {
+			"userId": "12063067",
+			"name": "臣訾",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/12063067/icon/ciyGaxmudPK7wsrqY0kDcwRj.jpeg"
 		},
-		{
-			"id": "51253",
-			"title": "毎月緊縛プラン",
-			"fee": 200,
-			"description": "Fanbox始めました！！試運転として、月額200円で、毎月独占でお縛りのオリジナル画像を一枚上げてきます！基本、話題な女の子(アニメ、ソシャゲー中心)で書こうと思います！どうぞよろしくお願いします！！",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/51253/cover/RwTIAoJsAnIWJWNYNAkhEfBg.jpeg",
-			"user": {
-				"userId": "13379747",
-				"name": "ひみつ",
-				"iconUrl": null
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "51253",
+		"title": "毎月緊縛プラン",
+		"fee": 200,
+		"description": "Fanbox始めました！！試運転として、月額200円で、毎月独占でお縛りのオリジナル画像を一枚上げてきます！基本、話題な女の子(アニメ、ソシャゲー中心)で書こうと思います！どうぞよろしくお願いします！！",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/51253/cover/RwTIAoJsAnIWJWNYNAkhEfBg.jpeg",
+		"user": {
+			"userId": "13379747",
+			"name": "ひみつ",
+			"iconUrl": null
 		},
-		{
-			"id": "94525",
-			"title": "水月的Fanbox计划",
-			"fee": 300,
-			"description": "水月的色图细化计划，应该每月能更新一次吧",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/94525/cover/A0AZiixXTt6NgsQw7NGQTDDF.jpeg",
-			"user": {
-				"userId": "13524241",
-				"name": "水月岩雲ー仕事募集中",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/13524241/icon/8XcQMzKzVLJlydmb1afNBg2w.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "94525",
+		"title": "水月的Fanbox计划",
+		"fee": 300,
+		"description": "水月的色图细化计划，应该每月能更新一次吧",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/94525/cover/A0AZiixXTt6NgsQw7NGQTDDF.jpeg",
+		"user": {
+			"userId": "13524241",
+			"name": "水月岩雲ー仕事募集中",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/13524241/icon/8XcQMzKzVLJlydmb1afNBg2w.jpeg"
 		},
-		{
-			"id": "61259",
-			"title": "レベル３：限定イラスト",
-			"fee": 1000,
-			"description": "イラストとマンガ以上 未公開イラスト1枚(縛りと拘束)，限定イラストは差分もありよ",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/61259/cover/JQRm1mgrOe5U8xIqPpIExkmE.jpeg",
-			"user": {
-				"userId": "17305623",
-				"name": "雪ノ嵐&异端丶",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/17305623/icon/86rMpiapcC8E7wNGhz8KHghK.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "61259",
+		"title": "レベル３：限定イラスト",
+		"fee": 1000,
+		"description": "イラストとマンガ以上 未公開イラスト1枚(縛りと拘束)，限定イラストは差分もありよ",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/61259/cover/JQRm1mgrOe5U8xIqPpIExkmE.jpeg",
+		"user": {
+			"userId": "17305623",
+			"name": "雪ノ嵐&异端丶",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/17305623/icon/86rMpiapcC8E7wNGhz8KHghK.jpeg"
 		},
-		{
-			"id": "2399",
-			"title": "資金援助プラン",
-			"fee": 500,
-			"description": "入ってくれる方は神様仏様マミさん\n支援頂いたお金は画材購入、環境整備、同人活動の為に使わせて頂きます。\n現状では頒布物の内容の一部や原稿進捗（全体図、線画など）を投稿して行きます\n何かしらの御礼的コンテンツを考え中（差分絵とか",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/2399/cover/SwWbY8hVcTq2R1LIcRVPonYi.jpeg",
-			"user": {
-				"userId": "17813543",
-				"name": "やんまーみ",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/17813543/icon/UYKInBg5X3ExpjAwmcnYZAOG.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "2399",
+		"title": "資金援助プラン",
+		"fee": 500,
+		"description": "入ってくれる方は神様仏様マミさん\n支援頂いたお金は画材購入、環境整備、同人活動の為に使わせて頂きます。\n現状では頒布物の内容の一部や原稿進捗（全体図、線画など）を投稿して行きます\n何かしらの御礼的コンテンツを考え中（差分絵とか",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/2399/cover/SwWbY8hVcTq2R1LIcRVPonYi.jpeg",
+		"user": {
+			"userId": "17813543",
+			"name": "やんまーみ",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/17813543/icon/UYKInBg5X3ExpjAwmcnYZAOG.jpeg"
 		},
-		{
-			"id": "87716",
-			"title": "とどおが頑張って描こうとするプラン",
-			"fee": 500,
-			"description": "１００円のプランの内容に加え、過去にpixivで上げた絵の高解像度版やボツ絵などが見れます。\r\nまた、とどおが支援に感謝して無理をしない範囲でがんばろうとします。\r\n",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/87716/cover/fL5I25T8uid0HGiVYH6QjqHN.jpeg",
-			"user": {
-				"userId": "18961759",
-				"name": "とどお",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/18961759/icon/7uqGq9JlT0XjdHSRiBAfs1Wi.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "87716",
+		"title": "とどおが頑張って描こうとするプラン",
+		"fee": 500,
+		"description": "１００円のプランの内容に加え、過去にpixivで上げた絵の高解像度版やボツ絵などが見れます。\r\nまた、とどおが支援に感謝して無理をしない範囲でがんばろうとします。\r\n",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/87716/cover/fL5I25T8uid0HGiVYH6QjqHN.jpeg",
+		"user": {
+			"userId": "18961759",
+			"name": "とどお",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/18961759/icon/7uqGq9JlT0XjdHSRiBAfs1Wi.jpeg"
 		},
-		{
-			"id": "20046",
-			"title": "イラスト気に入ったよ的な感じで・・・",
-			"fee": 300,
-			"description": "もしもpixiv等でのイラストで気に入った方がいましたら、投げ銭みたいな感じで支援していただけると嬉しいです。特に大きな見返りがあるわけではないのでご注意ください。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/20046/cover/fe1nD773JNAQld3Csw3LurpS.jpeg",
-			"user": {
-				"userId": "19116803",
-				"name": "かなとふ",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/19116803/icon/ph0eU9nf0g2RiTyZvo0ZANoJ.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "20046",
+		"title": "イラスト気に入ったよ的な感じで・・・",
+		"fee": 300,
+		"description": "もしもpixiv等でのイラストで気に入った方がいましたら、投げ銭みたいな感じで支援していただけると嬉しいです。特に大きな見返りがあるわけではないのでご注意ください。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/20046/cover/fe1nD773JNAQld3Csw3LurpS.jpeg",
+		"user": {
+			"userId": "19116803",
+			"name": "かなとふ",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/19116803/icon/ph0eU9nf0g2RiTyZvo0ZANoJ.jpeg"
 		},
-		{
-			"id": "95894",
-			"title": "おべんとプラン",
-			"fee": 500,
-			"description": "100円のプランに加え、pixivなどで公開したイラストの高解像度版や限定おまけ差分をご覧いただけます。\n\nご支援金は創作活動費として使用されます。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/95894/cover/strRAGNfkBdtU6kFOeIcQJNY.jpeg",
-			"user": {
-				"userId": "22553630",
-				"name": "桜屋敷とんこつ",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/22553630/icon/b6XKPWx6nZabxwPgFHlpXrC0.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "95894",
+		"title": "おべんとプラン",
+		"fee": 500,
+		"description": "100円のプランに加え、pixivなどで公開したイラストの高解像度版や限定おまけ差分をご覧いただけます。\n\nご支援金は創作活動費として使用されます。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/95894/cover/strRAGNfkBdtU6kFOeIcQJNY.jpeg",
+		"user": {
+			"userId": "22553630",
+			"name": "桜屋敷とんこつ",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/22553630/icon/b6XKPWx6nZabxwPgFHlpXrC0.jpeg"
 		},
-		{
-			"id": "79440",
-			"title": "500円プラン",
-			"fee": 500,
-			"description": "I will post illustrations for only supporters every month\r\n毎月サポーターのみにイラストを投稿します",
-			"coverImageUrl": null,
-			"user": {
-				"userId": "23311297",
-				"name": "nekomom",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/23311297/icon/NZTaY6CgR8zHuwywXHfIURqC.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "79440",
+		"title": "500円プラン",
+		"fee": 500,
+		"description": "I will post illustrations for only supporters every month\r\n毎月サポーターのみにイラストを投稿します",
+		"coverImageUrl": null,
+		"user": {
+			"userId": "23311297",
+			"name": "nekomom",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/23311297/icon/NZTaY6CgR8zHuwywXHfIURqC.jpeg"
 		},
-		{
-			"id": "85396",
-			"title": "ラフぽいぽい祭り",
-			"fee": 100,
-			"description": "ラフを載せまくる。以上です！よろしくお願いします！\r\n1週間に1~2回の更新を目標に頑張ります(｡ᵕᴗᵕ｡)\r\n",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/85396/cover/H0IqMyCwbwUQOLe6kICNYZA2.jpeg",
-			"user": {
-				"userId": "23626451",
-				"name": "にゆん",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/23626451/icon/c0X6sE0XAWId3KVWQqMhCgar.jpeg"
-			},
-			"hasAdultContent": false,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "85396",
+		"title": "ラフぽいぽい祭り",
+		"fee": 100,
+		"description": "ラフを載せまくる。以上です！よろしくお願いします！\r\n1週間に1~2回の更新を目標に頑張ります(｡ᵕᴗᵕ｡)\r\n",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/85396/cover/H0IqMyCwbwUQOLe6kICNYZA2.jpeg",
+		"user": {
+			"userId": "23626451",
+			"name": "にゆん",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/23626451/icon/c0X6sE0XAWId3KVWQqMhCgar.jpeg"
 		},
-		{
-			"id": "84482",
-			"title": "通常プラン",
-			"fee": 880,
-			"description": "現状のところプランは一つだけですので、すべての作品を閲覧することができます。",
-			"coverImageUrl": null,
-			"user": {
-				"userId": "23652509",
-				"name": "識林ほりう",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/23652509/icon/r4zsbbGehIK6QLuM4dO3iWkJ.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": false,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "84482",
+		"title": "通常プラン",
+		"fee": 880,
+		"description": "現状のところプランは一つだけですので、すべての作品を閲覧することができます。",
+		"coverImageUrl": null,
+		"user": {
+			"userId": "23652509",
+			"name": "識林ほりう",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/23652509/icon/r4zsbbGehIK6QLuM4dO3iWkJ.jpeg"
 		},
-		{
-			"id": "67599",
-			"title": "スタンダードプラン",
-			"fee": 400,
-			"description": "「継続的に支援したい！」という方向けのスタンダードなプランです。\n\nThis is a standard plan.\nFor those who want to support me continuously.",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/67599/cover/yf2vSvP7JDsigIdHjoFCpevH.jpeg",
-			"user": {
-				"userId": "25900946",
-				"name": "ogyadya",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/25900946/icon/DlFEK7OYdUzSvSdle9EBTEA9.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "67599",
+		"title": "スタンダードプラン",
+		"fee": 400,
+		"description": "「継続的に支援したい！」という方向けのスタンダードなプランです。\n\nThis is a standard plan.\nFor those who want to support me continuously.",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/67599/cover/yf2vSvP7JDsigIdHjoFCpevH.jpeg",
+		"user": {
+			"userId": "25900946",
+			"name": "ogyadya",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/25900946/icon/DlFEK7OYdUzSvSdle9EBTEA9.jpeg"
 		},
-		{
-			"id": "57468",
-			"title": "月刊誌",
-			"fee": 500,
-			"description": "お賽銭的なヤツ",
-			"coverImageUrl": null,
-			"user": {
-				"userId": "27569300",
-				"name": "仁外",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/27569300/icon/A85RkerebOnRg3B0PaLE1c63.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "57468",
+		"title": "月刊誌",
+		"fee": 500,
+		"description": "お賽銭的なヤツ",
+		"coverImageUrl": null,
+		"user": {
+			"userId": "27569300",
+			"name": "仁外",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/27569300/icon/A85RkerebOnRg3B0PaLE1c63.jpeg"
 		},
-		{
-			"id": "51441",
-			"title": "うなぎ丼",
-			"fee": 600,
-			"description": "公開しない差分の閲覧が可能になります。その上、毎月独占で拘束の画像を一枚上げてきます。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/51441/cover/qtSz3auZWlThSBv5TFFJcqQY.jpeg",
-			"user": {
-				"userId": "30716447",
-				"name": "ginklaga",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/30716447/icon/t1uxsE6MApu2Lkn2azwnJvHp.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "51441",
+		"title": "うなぎ丼",
+		"fee": 600,
+		"description": "公開しない差分の閲覧が可能になります。その上、毎月独占で拘束の画像を一枚上げてきます。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/51441/cover/qtSz3auZWlThSBv5TFFJcqQY.jpeg",
+		"user": {
+			"userId": "30716447",
+			"name": "ginklaga",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/30716447/icon/t1uxsE6MApu2Lkn2azwnJvHp.jpeg"
 		},
-		{
-			"id": "48637",
-			"title": "+他作品",
-			"fee": 1000,
-			"description": "「γ-ガンマ-」以外の作品のイラストも観覧出来る様になります。\r\nこちらのプランで「γ-ガンマ-」のイラストも全て観覧出来ます。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/48637/cover/zf7Ia0StIIv9eoDf2Y9H8xGZ.jpeg",
-			"user": {
-				"userId": "35438167",
-				"name": "γ",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/35438167/icon/X7POgmP3psmeubiiglej7qCV.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "48637",
+		"title": "+他作品",
+		"fee": 1000,
+		"description": "「γ-ガンマ-」以外の作品のイラストも観覧出来る様になります。\r\nこちらのプランで「γ-ガンマ-」のイラストも全て観覧出来ます。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/48637/cover/zf7Ia0StIIv9eoDf2Y9H8xGZ.jpeg",
+		"user": {
+			"userId": "35438167",
+			"name": "γ",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/35438167/icon/X7POgmP3psmeubiiglej7qCV.jpeg"
 		},
-		{
-			"id": "82919",
-			"title": "fan (+3pts/month)",
-			"fee": 300,
-			"description": "being a fan you get to see them exclusives c;",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/82919/cover/rgoQIUmWblcjGcjXmSuDu0zg.jpeg",
-			"user": {
-				"userId": "40169508",
-				"name": "crumbles",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/40169508/icon/buR2OoPLjCm1RagEvyHYatyC.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "82919",
+		"title": "fan (+3pts/month)",
+		"fee": 300,
+		"description": "being a fan you get to see them exclusives c;",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/82919/cover/rgoQIUmWblcjGcjXmSuDu0zg.jpeg",
+		"user": {
+			"userId": "40169508",
+			"name": "crumbles",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/40169508/icon/buR2OoPLjCm1RagEvyHYatyC.jpeg"
 		},
-		{
-			"id": "93759",
-			"title": "100円TIPS",
-			"fee": 100,
-			"description": "full-size picture and the process of my works only! I would be very thankful!\nこちらは原サイズ画像と創作流れしかありません\n只有原尺寸圖與我的感謝(´∀`)",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/93759/cover/BsXC8FH3Wxi3VfVV2OYa8tl5.jpeg",
-			"user": {
-				"userId": "42936714",
-				"name": "BLAM",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/42936714/icon/dOnO2ZaKTk91VORpBchIYAEc.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "93759",
+		"title": "100円TIPS",
+		"fee": 100,
+		"description": "full-size picture and the process of my works only! I would be very thankful!\nこちらは原サイズ画像と創作流れしかありません\n只有原尺寸圖與我的感謝(´∀`)",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/93759/cover/BsXC8FH3Wxi3VfVV2OYa8tl5.jpeg",
+		"user": {
+			"userId": "42936714",
+			"name": "BLAM",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/42936714/icon/dOnO2ZaKTk91VORpBchIYAEc.jpeg"
 		},
-		{
-			"id": "96263",
-			"title": "投げ銭プラン",
-			"fee": 100,
-			"description": "投げ銭のプランです。ちょっとしたおまけ等が見れる予定です。プランに興味がなくても、フォローやコメント、コミッション等していただけると励みになります。",
-			"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/96263/cover/UEN4nNSXxVictnIr2NqM3z2U.jpeg",
-			"user": {
-				"userId": "44433394",
-				"name": "Pita17",
-				"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/44433394/icon/MjeSA6YIUQHHCAtcAlMAfpht.jpeg"
-			},
-			"hasAdultContent": true,
-			"paymentMethod": "gmo_card"
-		}
-	]
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}, {
+		"id": "96263",
+		"title": "投げ銭プラン",
+		"fee": 100,
+		"description": "投げ銭のプランです。ちょっとしたおまけ等が見れる予定です。プランに興味がなくても、フォローやコメント、コミッション等していただけると励みになります。",
+		"coverImageUrl": "https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/96263/cover/UEN4nNSXxVictnIr2NqM3z2U.jpeg",
+		"user": {
+			"userId": "44433394",
+			"name": "Pita17",
+			"iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/44433394/icon/MjeSA6YIUQHHCAtcAlMAfpht.jpeg"
+		},
+		"creatorId": "madeToPassUnitTest",
+		"hasAdultContent": true,
+		"paymentMethod": "gmo_card"
+	}]
 }

--- a/test_PixivModel_fanbox.py
+++ b/test_PixivModel_fanbox.py
@@ -7,7 +7,7 @@ import unittest
 import demjson
 
 import PixivHelper
-from PixivModelFanbox import Fanbox, FanboxArtist, FanboxPost
+from PixivModelFanbox import FanboxArtist, FanboxPost
 
 temp = PixivHelper.__re_manga_index
 
@@ -21,90 +21,98 @@ class TestPixivModel_Fanbox(unittest.TestCase):
         reader = open('./test/Fanbox_supported_artist.json', 'r', encoding="utf-8")
         p = reader.read()
         reader.close()
-        result = Fanbox(p)
+        result = FanboxArtist.parseArtists(p)
         self.assertIsNotNone(result)
 
-        self.assertEqual(len(result.supportedArtist), 52)
-        self.assertTrue(4820 in result.supportedArtist)
-        self.assertTrue(11443 in result.supportedArtist)
-        self.assertTrue(226267 in result.supportedArtist)
+        self.assertEqual(len(result), 52)
+        self.assertTrue(4820 in [x.artistId for x in result])
+        self.assertTrue(11443 in [x.artistId for x in result])
+        self.assertTrue(226267 in [x.artistId for x in result])
 
     def testFanboxArtistPosts(self):
         reader = open('./test/Fanbox_artist_posts.json', 'r', encoding="utf-8")
         p = reader.read()
         reader.close()
-        result = FanboxArtist(15521131, p)
+
+        artist = FanboxArtist(15521131, "", "", None)
+        result = artist.parsePosts(p)
+        # result = FanboxArtist(15521131, p)
         self.assertIsNotNone(result)
 
-        self.assertEqual(result.artistId, 15521131)
-        self.assertTrue(result.hasNextPage)
-        self.assertTrue(len(result.nextUrl) > 0)
-        self.assertTrue(len(result.posts) > 0)
+        self.assertEqual(artist.artistId, 15521131)
+        self.assertTrue(artist.hasNextPage)
+        self.assertTrue(len(artist.nextUrl) > 0)
+        self.assertTrue(len(result) > 0)
 
-        for post in result.posts:
+        for post in result:
             self.assertFalse(post.is_restricted)
 
         # post-136761 image
-        self.assertEqual(result.posts[0].imageId, 136761)
-        self.assertTrue(len(result.posts[0].imageTitle) > 0)
-        self.assertTrue(len(result.posts[0].coverImageUrl) > 0)
-        self.assertEqual(result.posts[0].type, "image")
-        self.assertEqual(len(result.posts[0].images), 5)
+        self.assertEqual(result[0].imageId, 136761)
+        self.assertTrue(len(result[0].imageTitle) > 0)
+        self.assertTrue(len(result[0].coverImageUrl) > 0)
+        self.assertEqual(result[0].type, "image")
+        self.assertEqual(len(result[0].images), 5)
 
         # post-132919 text
-        self.assertEqual(result.posts[2].imageId, 132919)
-        self.assertTrue(len(result.posts[2].imageTitle) > 0)
-        self.assertIsNone(result.posts[2].coverImageUrl)
-        self.assertEqual(result.posts[2].type, "text")
-        self.assertEqual(len(result.posts[2].images), 0)
+        self.assertEqual(result[2].imageId, 132919)
+        self.assertTrue(len(result[2].imageTitle) > 0)
+        self.assertIsNone(result[2].coverImageUrl)
+        self.assertEqual(result[2].type, "text")
+        self.assertEqual(len(result[2].images), 0)
 
         # post-79695 image
-        self.assertEqual(result.posts[3].imageId, 79695)
-        self.assertTrue(len(result.posts[3].imageTitle) > 0)
-        self.assertIsNone(result.posts[3].coverImageUrl)
-        self.assertEqual(result.posts[3].type, "image")
-        self.assertEqual(len(result.posts[3].images), 4)
+        self.assertEqual(result[3].imageId, 79695)
+        self.assertTrue(len(result[3].imageTitle) > 0)
+        self.assertIsNone(result[3].coverImageUrl)
+        self.assertEqual(result[3].type, "image")
+        self.assertEqual(len(result[3].images), 4)
 
     def testFanboxArtistArticle(self):
         reader = open('./test/Fanbox_artist_posts_article.json', 'r', encoding="utf-8")
         p = reader.read()
         reader.close()
-        result = FanboxArtist(190026, p)
+
+        artist = FanboxArtist(190026, "", "", None)
+        result = artist.parsePosts(p)
+        # result = FanboxArtist(190026, p)
         self.assertIsNotNone(result)
 
-        self.assertEqual(result.artistId, 190026)
-        self.assertTrue(result.hasNextPage)
-        self.assertTrue(len(result.nextUrl) > 0)
-        self.assertTrue(len(result.posts) > 0)
+        self.assertEqual(artist.artistId, 190026)
+        self.assertTrue(artist.hasNextPage)
+        self.assertTrue(len(artist.nextUrl) > 0)
+        self.assertTrue(len(result) > 0)
 
         # post-201946 article
-        self.assertEqual(result.posts[0].imageId, 201946)
-        self.assertTrue(len(result.posts[0].imageTitle) > 0)
-        self.assertIsNone(result.posts[0].coverImageUrl)
-        self.assertEqual(result.posts[0].type, "article")
-        self.assertEqual(len(result.posts[0].images), 5)
-        self.assertEqual(len(result.posts[0].body_text), 1292)
+        self.assertEqual(result[0].imageId, 201946)
+        self.assertTrue(len(result[0].imageTitle) > 0)
+        self.assertIsNone(result[0].coverImageUrl)
+        self.assertEqual(result[0].type, "article")
+        self.assertEqual(len(result[0].images), 5)
+        self.assertEqual(len(result[0].body_text), 1292)
         # result.posts[0].WriteInfo("./201946.txt")
 
     def testFanboxArtistArticleFileMap(self):
         reader = open('./test/creator_with_filemap.json', 'r', encoding="utf-8")
         p = reader.read()
         reader.close()
-        result = FanboxArtist(190026, p)
+        artist = FanboxArtist(190026, "", "", None)
+        result = artist.parsePosts(p)
+        # result = FanboxArtist(190026, p)
         self.assertIsNotNone(result)
 
-        self.assertEqual(result.artistId, 190026)
-        self.assertTrue(result.hasNextPage)
-        self.assertTrue(len(result.nextUrl) > 0)
-        self.assertTrue(len(result.posts) > 0)
+        self.assertEqual(artist.artistId, 190026)
+        self.assertTrue(artist.hasNextPage)
+        self.assertTrue(len(artist.nextUrl) > 0)
+        self.assertTrue(len(result) > 0)
 
         # post-201946 article
-        self.assertEqual(result.posts[0].imageId, 210980)
-        self.assertTrue(len(result.posts[0].imageTitle) > 0)
-        self.assertIsNone(result.posts[0].coverImageUrl)
-        self.assertEqual(result.posts[0].type, "article")
-        self.assertEqual(len(result.posts[0].images), 15)
-        self.assertEqual(len(result.posts[0].body_text), 3006)
+        self.assertEqual(result[0].imageId, 210980)
+        self.assertTrue(len(result[0].imageTitle) > 0)
+        self.assertIsNone(result[0].coverImageUrl)
+        self.assertEqual(result[0].type, "article")
+        self.assertEqual(len(result[0].images), 15)
+        self.assertEqual(len(result[0].body_text), 3006)
 
         # result.posts[0].WriteInfo("./210980.txt")
 
@@ -112,21 +120,24 @@ class TestPixivModel_Fanbox(unittest.TestCase):
         reader = open('./test/creator_posts_with_video.json', 'r', encoding="utf-8")
         p = reader.read()
         reader.close()
-        result = FanboxArtist(711048, p)
+
+        artist = FanboxArtist(711048, "", "", None)
+        result = artist.parsePosts(p)
+        # result = FanboxArtist(711048, p)
         self.assertIsNotNone(result)
 
-        self.assertEqual(result.artistId, 711048)
-        self.assertTrue(result.hasNextPage)
-        self.assertTrue(len(result.nextUrl) > 0)
-        self.assertTrue(len(result.posts) > 0)
+        self.assertEqual(artist.artistId, 711048)
+        self.assertTrue(artist.hasNextPage)
+        self.assertTrue(len(artist.nextUrl) > 0)
+        self.assertTrue(len(result) > 0)
 
         # post-201946 article
-        self.assertEqual(result.posts[4].imageId, 330905)
-        self.assertTrue(len(result.posts[4].imageTitle) > 0)
-        self.assertEqual(result.posts[4].coverImageUrl, u'https://pixiv.pximg.net/c/1200x630_90_a2_g5/fanbox/public/images/post/330905/cover/3A2zPUg4s6iz17MM0Z45eWBj.jpeg')
-        self.assertEqual(result.posts[4].type, "video")
-        self.assertEqual(len(result.posts[4].images), 0)
-        self.assertEqual(len(result.posts[4].body_text), 99)
+        self.assertEqual(result[4].imageId, 330905)
+        self.assertTrue(len(result[4].imageTitle) > 0)
+        self.assertEqual(result[4].coverImageUrl, u'https://pixiv.pximg.net/c/1200x630_90_a2_g5/fanbox/public/images/post/330905/cover/3A2zPUg4s6iz17MM0Z45eWBj.jpeg')
+        self.assertEqual(result[4].type, "video")
+        self.assertEqual(len(result[4].images), 0)
+        self.assertEqual(len(result[4].body_text), 99)
 
         # result.posts[0].WriteInfo("./210980.txt")
 
@@ -134,20 +145,23 @@ class TestPixivModel_Fanbox(unittest.TestCase):
         reader = open('./test/creator_embedMap.json', 'r', encoding="utf-8")
         p = reader.read()
         reader.close()
-        result = FanboxArtist(68813, p)
+
+        artist = FanboxArtist(68813, "", "", None)
+        result = artist.parsePosts(p)
+        # result = FanboxArtist(68813, p)
         self.assertIsNotNone(result)
 
-        self.assertEqual(result.artistId, 68813)
-        self.assertFalse(result.hasNextPage)
-        self.assertTrue(len(result.posts) > 0)
+        self.assertEqual(artist.artistId, 68813)
+        self.assertFalse(artist.hasNextPage)
+        self.assertTrue(len(result) > 0)
 
         # post-201946 article
-        self.assertEqual(result.posts[0].imageId, 285502)
-        self.assertTrue(len(result.posts[0].imageTitle) > 0)
-        self.assertEqual(result.posts[0].coverImageUrl, u'https://pixiv.pximg.net/c/1200x630_90_a2_g5/fanbox/public/images/post/285502/cover/orx9TCsiPFi5sgDdbvg4zwkX.jpeg')
-        self.assertEqual(result.posts[0].type, "article")
-        self.assertEqual(len(result.posts[0].images), 7)
-        self.assertEqual(len(result.posts[0].body_text), 3164)
+        self.assertEqual(result[0].imageId, 285502)
+        self.assertTrue(len(result[0].imageTitle) > 0)
+        self.assertEqual(result[0].coverImageUrl, u'https://pixiv.pximg.net/c/1200x630_90_a2_g5/fanbox/public/images/post/285502/cover/orx9TCsiPFi5sgDdbvg4zwkX.jpeg')
+        self.assertEqual(result[0].type, "article")
+        self.assertEqual(len(result[0].images), 7)
+        self.assertEqual(len(result[0].body_text), 3164)
 
         # result.posts[0].WriteInfo("./285502.txt")
 
@@ -156,71 +170,83 @@ class TestPixivModel_Fanbox(unittest.TestCase):
         reader = open('./test/Fanbox_artist_posts_nextpage.json', 'r', encoding="utf-8")
         p2 = reader.read()
         reader.close()
-        result = FanboxArtist(91029, p2)
+
+        artist = FanboxArtist(91029, "", "", None)
+        result = artist.parsePosts(p2)
+        # result = FanboxArtist(91029, p2)
         self.assertIsNotNone(result)
 
-        self.assertEqual(result.artistId, 91029)
-        self.assertTrue(result.hasNextPage)
-        self.assertTrue(result.nextUrl is not None)
-        self.assertEqual(len(result.posts), 10)
+        self.assertEqual(artist.artistId, 91029)
+        self.assertTrue(artist.hasNextPage)
+        self.assertTrue(artist.nextUrl is not None)
+        self.assertEqual(len(result), 10)
 
     def testFanboxArtistPostsRestricted(self):
         reader = open('./test/Fanbox_artist_posts_restricted.json', 'r', encoding="utf-8")
         p = reader.read()
         reader.close()
-        result = FanboxArtist(15521131, p)
+
+        artist = FanboxArtist(15521131, "", "", None)
+        result = artist.parsePosts(p)
+        # result = FanboxArtist(15521131, p)
         self.assertIsNotNone(result)
 
-        self.assertEqual(result.artistId, 15521131)
-        self.assertTrue(result.hasNextPage)
-        self.assertTrue(len(result.nextUrl) > 0)
-        self.assertEqual(len(result.posts), 10)
+        self.assertEqual(artist.artistId, 15521131)
+        self.assertTrue(artist.hasNextPage)
+        self.assertTrue(len(artist.nextUrl) > 0)
+        self.assertEqual(len(result), 10)
 
-        for post in result.posts:
+        for post in result:
             self.assertTrue(post.is_restricted)
 
     def testFanboxArtistPostsRestrictedNextPage(self):
         reader = open('./test/Fanbox_artist_posts_next_page_restricted.json', 'r', encoding="utf-8")
         p = reader.read()
         reader.close()
-        result = FanboxArtist(15521131, p)
+        artist = FanboxArtist(15521131, "", "", None)
+        result = artist.parsePosts(p)
+        # result = FanboxArtist(15521131, p)
         self.assertIsNotNone(result)
 
-        self.assertEqual(result.artistId, 15521131)
-        self.assertFalse(result.hasNextPage)
-        self.assertTrue(result.nextUrl is None)
-        self.assertEqual(len(result.posts), 6)
+        self.assertEqual(artist.artistId, 15521131)
+        self.assertFalse(artist.hasNextPage)
+        self.assertTrue(artist.nextUrl is None)
+        self.assertEqual(len(result), 6)
 
-        self.assertTrue(result.posts[0].is_restricted)
-        self.assertFalse(result.posts[1].is_restricted)
+        self.assertTrue(result[0].is_restricted)
+        self.assertFalse(result[1].is_restricted)
 
     def testFanboxOldApi(self):
         reader = open('./test/fanbox-posts-old-api.json', 'r', encoding="utf-8")
         p = reader.read()
         reader.close()
-        result = FanboxArtist(104409, p)
+        artist = FanboxArtist(104409, "", "", None)
+        result = artist.parsePosts(p)
+        # result = FanboxArtist(104409, p)
         self.assertIsNotNone(result)
 
-        self.assertEqual(len(result.posts), 2)
-        self.assertEqual(result.posts[0].imageId, 916)
-        self.assertEqual(len(result.posts[0].images), 8)
-        print(result.posts[0].images)
-        self.assertEqual(result.posts[1].imageId, 915)
-        self.assertEqual(len(result.posts[1].images), 1)
-        print(result.posts[1].images)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].imageId, 916)
+        self.assertEqual(len(result[0].images), 8)
+        print(result[0].images)
+        self.assertEqual(result[1].imageId, 915)
+        self.assertEqual(len(result[1].images), 1)
+        print(result[1].images)
 
     def testFanboxNewApi(self):
         reader = open('./test/fanbox-posts-new-api.json', 'r', encoding="utf-8")
         p = reader.read()
         reader.close()
-        result = FanboxArtist(104409, p)
+        artist = FanboxArtist(104409, "", "", None)
+        result = artist.parsePosts(p)
+        # result = FanboxArtist(104409, p)
         self.assertIsNotNone(result)
 
-        self.assertEqual(len(result.posts), 10)
-        self.assertEqual(result.posts[0].imageId, 577968)
-        self.assertEqual(len(result.posts[0].images), 2)
-        self.assertEqual(result.posts[1].imageId, 535518)
-        self.assertEqual(len(result.posts[1].images), 2)
+        self.assertEqual(len(result), 10)
+        self.assertEqual(result[0].imageId, 577968)
+        self.assertEqual(len(result[0].images), 2)
+        self.assertEqual(result[1].imageId, 535518)
+        self.assertEqual(len(result[1].images), 2)
 
     def testFanboxNewApi2_MultiImages(self):
         reader = open('./test/Fanbox_post_with_multi_images.json', 'r', encoding="utf-8")
@@ -254,10 +280,12 @@ class TestPixivModel_Fanbox(unittest.TestCase):
         reader = open('./test/Fanbox_artist_posts.json', 'r', encoding="utf-8")
         p = reader.read()
         reader.close()
-        result = FanboxArtist(15521131, p)
+        artist = FanboxArtist(15521131, "", "", None)
+        result = artist.parsePosts(p)
+        # result = FanboxArtist(15521131, p)
         self.assertIsNotNone(result)
         root_dir = os.path.abspath(os.path.curdir)
-        post = result.posts[0]
+        post = result[0]
         image_url = post.images[0]
         current_page = 0
         fake_image_url = image_url.replace("{0}/".format(post.imageId), "{0}_p{1}_".format(post.imageId, current_page))
@@ -271,7 +299,7 @@ class TestPixivModel_Fanbox(unittest.TestCase):
 
             filename = PixivHelper.make_filename(filename_format,
                                                  post,
-                                                 artistInfo=result,
+                                                 artistInfo=artist,
                                                  tagsSeparator=" ",
                                                  tagsLimit=0,
                                                  fileUrl=fake_image_url,
@@ -288,7 +316,7 @@ class TestPixivModel_Fanbox(unittest.TestCase):
 
             filename = PixivHelper.make_filename(filename_format,
                                                  post,
-                                                 artistInfo=result,
+                                                 artistInfo=artist,
                                                  tagsSeparator=" ",
                                                  tagsLimit=0,
                                                  fileUrl=fake_image_url,
@@ -307,7 +335,7 @@ class TestPixivModel_Fanbox(unittest.TestCase):
 
             filename = PixivHelper.make_filename(filename_format,
                                                  post,
-                                                 artistInfo=result,
+                                                 artistInfo=artist,
                                                  tagsSeparator=" ",
                                                  tagsLimit=0,
                                                  fileUrl=fake_image_url,


### PR DESCRIPTION
1. Some minor format changes made by pyCharm
2. Moved codes to download FANBOX cover images from `processFanboxArtist` to `processFanboxImages`, because I don't think cover images should be downloaded if the post is not accessible
3. Post infomation (mainly just artist_id, post_id, title, feeRequired, workDate, updatedDate, type) would be written into database first thing after 'processFanboxImages' is called inside it, before retrieving post data row from database for comparison between the newly retrieved post updated date and that written in the database. Post would not be processed if it is restricted or download history exists. 
4. Then after everything is down, images downloaded and image info written to file, update the `updatedDate` in database
5. Added entry for download fanbox post by post ids, and some related logic in option parser thiingy