### PR TITLE
FANBOX database patch

### DIFF
--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1070,6 +1070,8 @@ def processFanboxImages(post, artist):
                                       "Skipping post: {0} bacause it was downloaded before.".format(post.imageId))
             return
 
+    post_files = []
+
     # cover image
     if post.coverImageUrl is not None:
         # fake the image_url for filename compatibility, add post id and pagenum
@@ -1098,6 +1100,8 @@ def processFanboxImages(post, artist):
                                             __config__.overwrite,
                                             __config__.retry,
                                             __config__.backupOldFile)
+
+        post_files.append((post.imageId, -1, filename))
         PixivHelper.get_logger().debug("Download %s result: %s", filename, result)
     else:
         PixivHelper.print_and_log("info", "No Cover Image for post: {0}.".format(post.imageId))
@@ -1140,6 +1144,8 @@ def processFanboxImages(post, artist):
                                                 False,  # __config__.overwrite somehow unable to get remote filesize
                                                 __config__.retry,
                                                 __config__.backupOldFile)
+            post_files.append((post.imageId, current_page, filename))
+
             PixivHelper.get_logger().debug("Download %s result: %s", filename, result)
 
             __config__.alwaysCheckFileSize = _oldvalue
@@ -1166,7 +1172,8 @@ def processFanboxImages(post, artist):
             reader.close()
         post.WriteHtml(html_template, __config__.useAbsolutePathsInHtml, filename + ".html")
 
-    __dbManager__.updatePostLastUpdateDate(post.imageId, post.updatedDate)
+    __dbManager__.insertPostImages(post_files)
+    __dbManager__.updatePostUpdateDate(post.imageId, post.updatedDate)
 
 
 def menu_fanbox_download_by_artist_or_creator_id(op_is_valid, args):

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1172,7 +1172,8 @@ def processFanboxImages(post, artist):
             reader.close()
         post.WriteHtml(html_template, __config__.useAbsolutePathsInHtml, filename + ".html")
 
-    __dbManager__.insertPostImages(post_files)
+    if len(post_files) > 0:
+        __dbManager__.insertPostImages(post_files)
     __dbManager__.updatePostUpdateDate(post.imageId, post.updatedDate)
 
 


### PR DESCRIPTION
In DBManager:
1. Added new table `fanbox_post_image` to record downloaded files
2. Moved FANBOX related methods together
3. Added logic to replace `save_name` in table `fanbox_post_image` inside method `replaceRootPath`
4. Added method `insertPostImages` to write/replace downloaded file records to table `fanbox_post_image`
5. Renamed method `updatePostLastUpdateDate` to `updatePostUpdateDate`
6. Added methods `cleanUpFanbox` and `interactiveCleanUpFanbox` which would be called after user selects `c` or `i`

In PixivUtil2:
Inside method `processFanboxImages`:
1. Added local list variable `post_files` to store downloaded post files
2. After downloading cover images and each file of a post, append the needed  values to `post_files`
3. Call `__dbManager__.insertPostImages` to write `post_files` into database after processing all files of a post