### PR TITLE
FANBOX enhancement 2

### DIFF
--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -311,7 +311,7 @@ class PixivBrowser(mechanize.Browser):
     def fanboxLoginUsingCookie(self, login_cookie=None):
         """  Log in to Pixiv using saved cookie, return True if success """
         result = False
-
+        parsed = ""
         if login_cookie is None or len(login_cookie) == 0:
             login_cookie = self._config.cookieFanbox
 
@@ -331,7 +331,7 @@ class PixivBrowser(mechanize.Browser):
                 res.close()
             except BaseException:
                 PixivHelper.get_logger().error('Error at fanboxLoginUsingCookie(): %s', sys.exc_info())
-                return False
+                self.cookiejar.clear("fanbox.cc")
 
             if '"user":{"isLoggedIn":true' in str(parsed):
                 result = True

--- a/PixivConstant.py
+++ b/PixivConstant.py
@@ -24,6 +24,6 @@ PIXIVUTIL_SIZE_LIMIT_SMALLER = 8
 PIXIVUTIL_SKIP_DUPLICATE_NO_WAIT = 9
 PIXIVUTIL_ABORTED = 9999
 
-HTML_TEMPLATE = '<!DOCTYPE html> <html lang="ja"> <head> <title>%artistName% - %imageTitle%</title> <meta charset="utf-8"> <style type="text/css"> .container {margin:auto; display:inline-block; padding:10px;} body {text-align:center;} h1 {text-align:left;} h5 {text-align:left;} p {text-align:left;padding-left:5%;padding-right:5%;} img {max-width:100%;margin:auto} a {margin:auto;} </style> </head> <body> <div class="container"> <div class="cover"> <img src="%coverImageUrl%"/> </div> <div class="title"> <h1>%imageTitle%</h1> <h5>%worksDate%</h5> </div> <div class="caption"> %body_text% </div> </div> </body> </html>'
+HTML_TEMPLATE = '<!DOCTYPE html> <html lang="ja"> <head> <title>%artistName% - %imageTitle%</title> <meta charset="utf-8"> <style type="text/css"> div{overflow:auto; margin:auto; text-align:center;} h1{text-align:left;} h5{text-align:left;} p{text-align:left; padding-left:5%;padding-right:5%;} img{max-width:100%;} a{margin:auto;} .root{display:inline-block; padding:10px;} .non-article.root{position:fixed; height:85%; top:0px; bottom:15%; left:0px; right:0px;} .non-article.text{position:fixed; height:15%; bottom:0px; left:0px; right:0px;} </style> </head> <body> <div class="root"> %coverImage% <div class="title"> <h1>%imageTitle%</h1> <h5>%worksDate%</h5> </div> %body_text(article)% %images(non-article)% %text(non-article)% </div> </body> </html>'
 
 BUFFER_SIZE = 8192

--- a/PixivDBManager.py
+++ b/PixivDBManager.py
@@ -253,11 +253,7 @@ class PixivDBManager(object):
             writer.write(sep.join(columns))
             writer.write('\r\n')
             for row in c:
-                for string in row:
-                    # Unicode write!!
-                    data = str(string)
-                    writer.write(data)
-                    writer.write(sep)
+                writer.write(sep.join([str(x) for x in row]))
                 writer.write('\r\n')
             writer.write('###END-OF-FILE###')
             writer.close()

--- a/PixivModelFanbox.py
+++ b/PixivModelFanbox.py
@@ -368,11 +368,30 @@ class FanboxPost(object):
             PixivHelper.get_logger().exception("Error when saving article html: %s, file is saved to: %s.html",
                                                filename, self.imageId)
 
-        page = html_template.replace("%coverImageUrl%", self.coverImageUrl or "")
+        cover_image = ""
+        if self.coverImageUrl:
+            cover_image = f'<div class="cover"><img src="{self.coverImageUrl}"/></div>'
+        page = html_template.replace("%coverImage%", cover_image)
+        page = page.replace("%coverImageUrl%", self.coverImageUrl or "")
         page = page.replace("%artistName%", self.parent.artistName)
         page = page.replace("%imageTitle%", self.imageTitle)
         page = page.replace("%worksDate%", self.worksDate)
-        page = page.replace("%body_text%", self.body_text or "")
+
+        token_body_text = ""
+        token_images = ""
+        token_text = ""
+        if self.type == "article":
+            token_body_text = f'<div class="article">{self.body_text}</div>'
+        else:
+            token_images = '<div class="non-article images">{0}</div>'.format(
+                "".join(['<a href="{0}">{1}</a>'.format(x,
+                f'<img scr="{0}"/>' if x[x.rindex(".")+1:].lower() in ["jpg", "jpeg", "png", "bmp"] else os.path.basename(x))for x in self.images]))
+            token_text = '<div class="non-article text">{0}</div>'.format(
+                "".join(['<p>{0}</p>'.format(x.rstrip()) for x in self.body_text.split("\n")]))
+
+        page = page.replace("%body_text(article)%", token_body_text)
+        page = page.replace("%images(non-article)%", token_images)
+        page = page.replace("%text(non-article)%", token_text)
 
         page = BeautifulSoup(page, features="html5lib")
         imageATags = page.find_all("a", attrs={"href": True})
@@ -380,10 +399,9 @@ class FanboxPost(object):
             tag = imageATag.img
             if tag:
                 tag["src"] = imageATag["href"]
-        if self.coverImageUrl is None:
-            cover_div = page.find("div", attrs={"class": "cover"})
-            if cover_div:
-                cover_div.decompose()
+        root = page.find("div", attrs={"class": "root"})
+        if root:
+            root["class"].append("non-article" if self.type!="article" else "article")
         page = page.prettify()
         html_dir = os.path.dirname(filename)
         for k, v in self.linkToFile.items():

--- a/PixivModelFanbox.py
+++ b/PixivModelFanbox.py
@@ -385,7 +385,7 @@ class FanboxPost(object):
         else:
             token_images = '<div class="non-article images">{0}</div>'.format(
                 "".join(['<a href="{0}">{1}</a>'.format(x,
-                f'<img scr="{0}"/>' if x[x.rindex(".")+1:].lower() in ["jpg", "jpeg", "png", "bmp"] else os.path.basename(x))for x in self.images]))
+                f'<img scr="{0}"/>' if x[x.rindex(".")+1:].lower() in ["jpg", "jpeg", "png", "bmp"] else x)for x in self.images]))
             token_text = '<div class="non-article text">{0}</div>'.format(
                 "".join(['<p>{0}</p>'.format(x.rstrip()) for x in self.body_text.split("\n")]))
 

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1071,11 +1071,9 @@ def processFanboxImages(post, artist):
             updated_date = result[5]
             if updated_date is not None and post.updatedDateDatetime <= datetime_z.parse_datetime(updated_date):
                 flag_processed = True
-    flag_download_cover = ((not post.is_restricted) or __config__.downloadCoverWhenRestricted) and (not flag_processed)
-
 
     try:
-        if flag_download_cover:
+        if ((not post.is_restricted) or __config__.downloadCoverWhenRestricted) and (not flag_processed):
             # cover image
             if post.coverImageUrl is not None:
                 # fake the image_url for filename compatibility, add post id and pagenum

--- a/readme.md
+++ b/readme.md
@@ -306,28 +306,28 @@ dateformat   ==> Pixiv DateTime format, leave blank to use default format for
 autoAddMember ==> automatically save member id to db for all download.
 
 ## [FANBOX]
-filenameformatfanboxcover  ==> Similar like filename format, but for FANBOX post over images
-filenameformatfanboxcontent  ==> Similar like filename format, but for files inside FANBOX posts.
-filenameformatfanboxinfo  ==> Similar like filename format, but for info dumps.
-writehtml ==> set to `True` to write FANBOX post into HTMLs. Uses `filenameformatfanboxinfo` for filename.
-                        Article type FANBOX posts will certainly be written into HTMLs, non-article type posts
-                        uses `mintextlengthfornonarticle` and `minimagecountfornonarticle` to control.
-                        set to `False` to not write any post into HTMLs, whichever type.
-mintextlengthfornonarticle ==> Works with `minimagecountfornonarticle`. 
-                                                  When `writehtml` is set to `True`, a non-article post should contain
-                                                  text longer than this value to be written into HTML.
-minimagecountfornonarticle ==> Works with `minimagecountfornonarticle`.
-                                                     When `writehtml` is set to `True`, a non-article post should contain at
-                                                     least this many files/images to be written into HTML.
-useabsolutepathsinhtml ==> set to `True` to use absolute paths in HTMLs, 
-downloadcoverwhenrestricted ==> set to `True` to still download FANBOX post cover images
-                                                       when you don't have access to them
-checkdbprocesshistory ==> Each FANBOX post has a `updated date`, which will be recorded in database
-                                            after each post is processed. Set to `True` to check this recorded value in
-                                            database. If record does not exist or it's no earlier than the newly retrieved
-                                            date, which indicates that the post has not been changed since last time,
-                                            this post would be skipped, otherwise it will be processed, and update the 
-                                            record with new `updated date`.
+filenameFormatFanboxCover  ==> Similar like filename format, but for FANBOX post over images
+filenameFormatFanboxContent  ==> Similar like filename format, but for files inside FANBOX posts.
+filenameFormatFanboxInfo  ==> Similar like filename format, but for info dumps.
+writeHtml ==> set to `True` to write FANBOX post into HTMLs, `False` to not to, whichever type post. 
+	      Uses `filenameformatfanboxinfo` for filename.
+	      Article type FANBOX posts will certainly be written into HTMLs, non-article type
+	      posts use `mintextlengthfornonarticle` and `minimagecountfornonarticle` to control.
+minTextLengthForNonArticle ==> Works with `minimagecountfornonarticle`. 
+			       When `writehtml` is set to `True`, a non-article post should contain
+			       text longer than this value to be written into HTML. 
+minImageCountForNonArticle ==> Works with `minimagecountfornonarticle`.
+			       When `writehtml` is set to `True`, a non-article post should contain
+			       at least this many files/images to be written into HTML.
+useAbsolutePathsInHtml ==> set to `True` to use absolute paths in HTMLs, `False` to use relative paths.
+downloadCoverWhenRestricted ==> set to `True` to still download FANBOX post cover images
+			        when you don't have access to them
+checkDBProcessHistory ==> Each FANBOX post has a `updated date`, which will be recorded in database
+		          after each post is processed. Set to `True` to check this recorded value in
+		          database. If record does not exist or it's no earlier than the newly retrieved
+		          date, which indicates that the post has not been changed since last time,
+		          this post would be skipped, otherwise it will be processed, and update the 
+		          record with new `updated date`.
 ```
 ## [Network]
 ```

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,10 @@
   - Delete image by image_id
   - Delete member and image (cascade deletion)
   - Blacklist image by image_id
+  - Show all deleted member
+  - Export FANBOX post list
+  - Delete FANBOX download history by member_id
+  - Delete FANBOX download history by post_id
   - Clean Up Database (remove db entry if downloaded file is missing)
 - Export user bookmark (member_id) to a text files.
 
@@ -240,7 +244,7 @@ Q6: httperror_seek_wrapper: HTTP Error 403: request disallowed by robots.txt
                         f1 - Download from supported artists (FANBOX)
                             (required: Max Page)
                         f2 - Download by artist/creator id (FANBOX)
-                            (required: artist id, followed with Max Page)
+                            (required: artist(digits only)/creator id, followed with Max Page)
                         f3 - Download by post id (FANBOX)
                             (required: post ids, separated with space)
                         f4 - Download from followed artists (FANBOX)
@@ -300,6 +304,30 @@ dateformat   ==> Pixiv DateTime format, leave blank to use default format for
 		 %d = Day, %m = Month, %Y = Year (4 digit), %H = Hour (24h)
 		 %M = Minute, %S = Seconds
 autoAddMember ==> automatically save member id to db for all download.
+
+## [FANBOX]
+filenameformatfanboxcover  ==> Similar like filename format, but for FANBOX post over images
+filenameformatfanboxcontent  ==> Similar like filename format, but for files inside FANBOX posts.
+filenameformatfanboxinfo  ==> Similar like filename format, but for info dumps.
+writehtml ==> set to `True` to write FANBOX post into HTMLs. Uses `filenameformatfanboxinfo` for filename.
+                        Article type FANBOX posts will certainly be written into HTMLs, non-article type posts
+                        uses `mintextlengthfornonarticle` and `minimagecountfornonarticle` to control.
+                        set to `False` to not write any post into HTMLs, whichever type.
+mintextlengthfornonarticle ==> Works with `minimagecountfornonarticle`. 
+                                                  When `writehtml` is set to `True`, a non-article post should contain
+                                                  text longer than this value to be written into HTML.
+minimagecountfornonarticle ==> Works with `minimagecountfornonarticle`.
+                                                     When `writehtml` is set to `True`, a non-article post should contain at
+                                                     least this many files/images to be written into HTML.
+useabsolutepathsinhtml ==> set to `True` to use absolute paths in HTMLs, 
+downloadcoverwhenrestricted ==> set to `True` to still download FANBOX post cover images
+                                                       when you don't have access to them
+checkdbprocesshistory ==> Each FANBOX post has a `updated date`, which will be recorded in database
+                                            after each post is processed. Set to `True` to check this recorded value in
+                                            database. If record does not exist or it's no earlier than the newly retrieved
+                                            date, which indicates that the post has not been changed since last time,
+                                            this post would be skipped, otherwise it will be processed, and update the 
+                                            record with new `updated date`.
 ```
 ## [Network]
 ```
@@ -369,8 +397,6 @@ tagsLimit	==> Number of tags to be used for %tags% meta in filename.
 writeimageinfo  ==> set to 'True' to export the image information to text file.
                     The filename is following the image filename + .txt.
 writeImageJSON
-writeHtml
-useAbsolutePathsInHtml
 verifyimage     ==> Do image and zip checking after download. Set the value to
                     True to enable.
 writeUrlInDescription ==> Write all url found in the image description to a text
@@ -485,7 +511,7 @@ Available for filenameFormat and filenameMangaFormat:
 -> %title%
    Image title, usually in japanese character.
 -> %tags%
-   Image tags, usually in japanese character.
+   Image tags, usually in japanese character. (not implemented for FANBOX yet)
 -> %works_date%
    Works date, complete with time.
 -> %works_date_only%

--- a/template.html
+++ b/template.html
@@ -4,21 +4,19 @@
 <title>%artistName% - %imageTitle%</title>
 <meta charset="utf-8">
 <style type="text/css">
-.container {margin:auto; display:inline-block; padding:10px;} body {text-align:center;} h1 {text-align:left;} h5 {text-align:left;} p {text-align:left;padding-left:5%;padding-right:5%;} img {max-width:100%;margin:auto} a {margin:auto;}
+div{overflow:auto; margin:auto; text-align:center;} h1{text-align:left;} h5{text-align:left;} p{text-align:left; padding-left:5%;padding-right:5%;} img{max-width:100%;} a{margin:auto;} .root{display:inline-block; padding:10px;} .non-article.root{position:fixed; height:85%; top:0px; bottom:15%; left:0px; right:0px;} .non-article.text{position:fixed; height:15%; bottom:0px; left:0px; right:0px;}
 </style>
 </head>
 <body>
-<div class="container">
-<div class="cover">
-<img src="%coverImageUrl%"/>
-</div>
+<div class="root">
+%coverImage%
 <div class="title">
 <h1>%imageTitle%</h1>
 <h5>%worksDate%</h5>
 </div>
-<div class="caption">
-%body_text%
-</div>
+%body_text(article)%
+%images(non-article)%
+%text(non-article)%
 </div>
 </body>
 </html>


### PR DESCRIPTION
Main idea:
1. File formats for FANBOX posts
 - 3 separate formats for cover images, images inside posts, and post info
2. Options to write HTML for posts that are not article type
 - two new options for deciding whether to download a non-article post into HTML,
 - updated html template so it could be used for both article and non-article posts
3. An option to decide whether to download cover images when posts are restricted
4. An option to decide whether to check database download history to decide whether to download a post or not
5. Move FANBOX options together under `FANBOX` section

Others:
1. PixivConfig optimization
2. DBManager minor correction
3. Optimization for updating FANBOX cookie

For details please refer to each commit
