### PR TITLE
Download progress print, config, and fanbox artists

### DIFF
--- a/PixivDownloadHandler.py
+++ b/PixivDownloadHandler.py
@@ -246,7 +246,7 @@ def perform_download(url, file_size, filename, overwrite, config, referer=None, 
     if referer is None:
         referer = config.referer
     # actual download
-    PixivHelper.print_and_log(None, '\rStart downloading...', newline=False)
+    PixivHelper.print_and_log(None, 'Start downloading...\r', newline=False)
     # fetch filesize
     req = PixivHelper.create_custom_request(url, config, referer)
     br = PixivBrowserFactory.getBrowser(config=config)

--- a/PixivHelper.py
+++ b/PixivHelper.py
@@ -678,7 +678,7 @@ def print_progress(curr, total, max_msg_length=80):
 
     if total > 0:
         complete = int((curr * animBarLen) / total)
-        msg = f"[{'|' * complete:{animBarLen}}] {size_in_str(curr)} of {size_in_str(total)}"
+        msg = f" [{'|' * complete:{animBarLen}}] {size_in_str(curr)} of {size_in_str(total)}"
 
     else:
         # indeterminite
@@ -687,7 +687,7 @@ def print_progress(curr, total, max_msg_length=80):
         # Use nested replacement field to specify the precision value. This limits the maximum print
         # length of the progress bar. As pos changes, the starting print position of the anim string
         # also changes, thus producing the scrolling effect.
-        msg = f'[{anim[animBarLen + 3 - pos:]:.{animBarLen}}] {size_in_str(curr)}'
+        msg = f' [{anim[animBarLen + 3 - pos:]:.{animBarLen}}] {size_in_str(curr)}'
 
     curr_msg_length = len(msg)
     print_and_log(None, msg.ljust(max_msg_length, " "), end='\r')


### PR DESCRIPTION
1. Some output print optimization for downloading
    before:
 ....|||.............] 805.77 KiB      ] 805.77 KiB
 Completed in 1.223042s (658.82 KiB/s)
 done.
    after:
[....|||.............] 805.77 KiB  Completed in 1.223042s (658.82 KiB/s)
 done.

2. Load config before processing each FANBOX aritst in menu_fanbox_download_from_artist
3. Some changes for PixivConfig to avoid writing configuration to file if it's not changed
- 1. Added class field `__props` in `PixivConfig` to store all option names
- 2. Added instance field '__initialized` and `__modified`
- The above will be used in `__setattr__`
- `__initialized` will be set to true at the end of `__init__`
- 
- 1. If the instance is initialized, and the new attribute is in `__props` and the attribute's value is new, `__modified` would be set to true with overriden method `__setattr__`
- 2. When calling `writeConfig`, first check `__modified`, if it's true, then continue and set `__modified` to false, otherwise return