### PR TITLE
Download progress print, config, and fanbox artists

### DIFF
--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -41,6 +41,8 @@ class PixivConfig():
     '''Configuration class'''
     __logger = PixivHelper.get_logger()
     configFileLocation = "config.ini"
+    __initialized = False
+    __modified = False
 
     __items = [
         ConfigItem("Network", "useProxy", False),
@@ -166,10 +168,23 @@ class PixivConfig():
 
     proxy = {"http": "", "https": "", }
 
+    __props = [x.option for x in __items]
+
     def __init__(self):
         for item in self.__items:
             setattr(self, item.option, item.default)
         self.proxy = {'http': self.proxyAddress, 'https': self.proxyAddress}
+        self.__initialized = True
+        self.__modified = False
+
+    def __setattr__(self, key, value):
+        if self.__initialized:
+            if key in PixivConfig.__props:
+                if self.__getattribute__(key) != value:
+                    self.__modified = True
+                else:
+                    return
+        super(PixivConfig, self).__setattr__(key, value)
 
     def loadConfig(self, path=None):
         if path is not None:
@@ -227,11 +242,13 @@ class PixivConfig():
         if haveError:
             print('Configurations with invalid value are set to default value.')
             self.writeConfig(error=True, path=self.configFileLocation)
-
+        self.__modified = False
         print('done.')
 
     # -UI01B------write config
     def writeConfig(self, error=False, path=None):
+        if not self.__modified:
+            return
         '''Backup old config if exist and write updated config.ini'''
         print('Writing config file...', end=' ')
         config = configparser.RawConfigParser()
@@ -267,7 +284,7 @@ class PixivConfig():
         except BaseException:
             self.__logger.exception('Error at writeConfig()')
             raise
-
+        self.__modified = False
         print('done.')
 
     def printConfig(self):

--- a/PixivHelper.py
+++ b/PixivHelper.py
@@ -629,13 +629,11 @@ def download_image(url, filename, res, file_size, overwrite):
             # check if downloaded file is complete
             if file_size > 0 and curr == file_size:
                 total_time = (datetime.now() - start_time).total_seconds()
-                print_and_log(None, "")
                 print_and_log(None, f' Completed in {total_time}s ({speed_in_str(file_size, total_time)})')
                 break
 
             elif curr == prev:  # no file size info
                 total_time = (datetime.now() - start_time).total_seconds()
-                print_and_log(None, "")
                 print_and_log(None, f' Completed in {total_time}s ({speed_in_str(curr, total_time)})')
                 break
 
@@ -678,7 +676,7 @@ def print_progress(curr, total, max_msg_length=80):
 
     if total > 0:
         complete = int((curr * animBarLen) / total)
-        msg = f"[{'|' * complete:{animBarLen}}] {size_in_str(curr)} of {size_in_str(total)}"
+        msg = f"\r[{'|' * complete:{animBarLen}}] {size_in_str(curr)} of {size_in_str(total)}"
 
     else:
         # indeterminite
@@ -687,10 +685,10 @@ def print_progress(curr, total, max_msg_length=80):
         # Use nested replacement field to specify the precision value. This limits the maximum print
         # length of the progress bar. As pos changes, the starting print position of the anim string
         # also changes, thus producing the scrolling effect.
-        msg = f'[{anim[animBarLen + 3 - pos:]:.{animBarLen}}] {size_in_str(curr)}'
+        msg = f'\r[{anim[animBarLen + 3 - pos:]:.{animBarLen}}] {size_in_str(curr)}'
 
     curr_msg_length = len(msg)
-    print_and_log(None, msg.ljust(max_msg_length, " "), end='\r')
+    print_and_log(None, msg.ljust(max_msg_length, " "), newline=False)
 
     return curr_msg_length if curr_msg_length > max_msg_length else max_msg_length
 

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1023,9 +1023,9 @@ def menu_fanbox_download_from_artist(op_is_valid, via, args):
         PixivHelper.print_and_log("info", f"No {via_type} artist!")
         return
     PixivHelper.print_and_log("info", f"Found {len(artists)} {via_type} artist(s)")
-    print(", ".join(str(artists)))
 
     for artist in artists:
+        __config__.loadConfig(path=configfile)
         __br__.fanboxUpdateArtistToken(artist)
         # Issue #567
         try:


### PR DESCRIPTION
1. Some output print optimization for downloading
    before:
 ....|||.............] 805.77 KiB      ] 805.77 KiB
 Completed in 1.223042s (658.82 KiB/s)
 done.
    after:
[....|||.............] 805.77 KiB  Completed in 1.223042s (658.82 KiB/s)
 done.

2. Load config before processing each FANBOX aritst in menu_fanbox_download_from_artist
3. Some changes for PixivConfig to avoid writing configuration to file if it's not changed
- 1. Added class field `__props` in `PixivConfig` to store all option names
- 2. Added instance field '__initialized` and `__modified`
- The above will be used in `__setattr__`
- `__initialized` will be set to true at the end of `__init__`
- 
- 1. If the instance is initialized, and the new attribute is in `__props` and the attribute's value is new, `__modified` would be set to true with overriden method `__setattr__`
- 2. When calling `writeConfig`, first check `__modified`, if it's true, then continue and set `__modified` to false, otherwise return