### PR TITLE
Fix shebang of PixivUtil2.py

### DIFF
--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # flake8: noqa:E501,E128,E127
 import codecs


### PR DESCRIPTION
Explanation: The space between # and !  breaks the shebang. Which prevents to run PixivUtil2 from source code on Linux (and other kind of *nixes).

It is recommended to review your code style settings of your used IDE, to prevent this issue again.