### PR TITLE
Minor changes to PixivFanboxHandler, PixivUtil2, readme

### DIFF
--- a/PixivFanboxHandler.py
+++ b/PixivFanboxHandler.py
@@ -68,7 +68,7 @@ def process_fanbox_post(caller, config, post, artist):
     # caller function/method
     # TODO: ideally to be removed or passed as argument
     db = caller.__dbManager__
-    config.loadConfig(path=caller.configfile)
+    # config.loadConfig(path=caller.configfile)
     br = PixivBrowserFactory.getBrowser()
 
     db.insertPost(artist.artistId, post.imageId, post.imageTitle, post.feeRequired, post.worksDate, post.type)

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1058,6 +1058,7 @@ def menu_fanbox_download_by_post_id(op_is_valid, args):
         try:
             post = __br__.fanboxGetPostById(post_id)
             processFanboxPost(post, post.parent)
+            del post
         except KeyboardInterrupt:
             choice = input("Keyboard Interrupt detected, continue to next post (Y/N)").rstrip("\r")
             if choice.upper() == 'N':
@@ -1067,7 +1068,6 @@ def menu_fanbox_download_by_post_id(op_is_valid, args):
                 continue
         except PixivException as pex:
             PixivHelper.print_and_log("error", "Error processing FANBOX post: {0} ==> {1}".format(post_id, pex.message))
-        del post
 
 
 def processFanboxArtistById(artist_id, end_page, title_prefix=""):

--- a/readme.md
+++ b/readme.md
@@ -340,11 +340,11 @@ downloadCoverWhenRestricted ==> Set to 'True' to download FANBOX post cover imag
                                 they are restricted.
 checkDBProcessHistory       ==> Each FANBOX post has a updated_date value, which will be 
                                 recorded/updated in database after it is processed.
-                            --> When set to 'True', the values in database would be checked when
+                            --> When this is 'True', the values in database would be checked when
 			        processing each post. If record is no earlier than the newly
 				retrieved date, which means that the post has not been processed 
 				at all or changed since last time, the post would be skipped.
-                            --> When set to 'False', posts will be processed anyways.
+                            --> When this is 'False', posts will be processed anyways.
 ```
 ## [Network]
 ```
@@ -667,11 +667,11 @@ http://www.pixiv.net/member_illust.php?id=123456
 -> "%worksDate%"
    Published date of the post in clear text.
 -> %body_text(article)%
-   This only works if the post is an article type post.
+   This works for article type posts only.
    A 'div' token with its 'class' set to 'article', and the post's content,
    which is already formatted HTML if the post is article, as its inner text.
 -> %images(non-article)%
-   This only works if the posts is a none-article type post.
+   This works for none-article type posts only.
    A 'div' token with its 'class' set to 'non-article images', and 'a' tokens
    of all files in the post as its children tokens.
    For each 'a' token, its 'href' would be url to the file, and the inner text
@@ -679,7 +679,7 @@ http://www.pixiv.net/member_illust.php?id=123456
    file's extension is 'jpg', 'jpeg', 'png' or 'bmp'. Otherwise the inner text
    would simply be the url to the file.
 -> %text(non-article)%
-   This only works if the posts is a none-article type post.
+   This works for none-article type posts only.
    A 'div' token with its 'class' set to 'non-article text' and all paragraphs
    of text put in 'p' tokens as its children tokens.
 ```


### PR DESCRIPTION
1. Commented `config.loadConfig(path=caller.configfile)` inside `process_fanbox_post`
- I don't think it's necessary to read config for each post. For each artist? Maybe, as some users requested.
2. In PixivUtil2, moved `del post` into the `try... except...` before it in `menu_fanbox_download_by_post_id`
3. Some grammatical adjustments in readme