### PR TITLE
Implemented 804

### DIFF
--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -901,6 +901,8 @@ class PixivBrowser(mechanize.Browser):
             artist.artistName = pixivArtist.artistName
             artist.artistToken = pixivArtist.artistToken
             return artist
+        else:
+            raise PixivException("Id does not exist", errorCode=PixivException.USER_ID_NOT_EXISTS)
 
     def fanboxGetPostsFromArtist(self, artist=None, next_url=""):
         ''' get all posts from the supported user

--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -145,6 +145,7 @@ class PixivConfig():
         ConfigItem("FANBOX", "useAbsolutePathsInHtml", False),
         ConfigItem("FANBOX", "downloadCoverWhenRestricted", False),
         ConfigItem("FANBOX", "checkDBProcessHistory", False),
+        ConfigItem("FANBOX", "listPathFanbox", "listfanbox.txt"),
 
         ConfigItem("FFmpeg", "ffmpeg", "ffmpeg"),
         ConfigItem("FFmpeg", "ffmpegCodec", "libvpx-vp9"),

--- a/PixivModelFanbox.py
+++ b/PixivModelFanbox.py
@@ -23,6 +23,7 @@ class FanboxArtist(object):
 
     SUPPORTING = 0
     FOLLOWING = 1
+    CUSTOM = 2
 
     @classmethod
     def parseArtistIds(cls, page):

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -746,7 +746,7 @@ def menu_fanbox_download_by_id(op_is_valid, args, options):
 
         PixivHelper.print_and_log('info', "Member IDs: {0}".format(member_ids))
 
-    for member_id, index in enumerate(member_ids, start=1):
+    for index, member_id in enumerate(member_ids, start=1):
         PixivFanboxHandler.process_fanbox_artist_by_id(sys.modules[__name__],
                                                        __config__,
                                                        member_id,

--- a/readme.md
+++ b/readme.md
@@ -254,13 +254,16 @@ Please refer run with `--help` for latest information.
                         12 - Download by Group ID
                             (required: Group ID, limit, and process external[y/n])
                         f1 - Download from supported artists (FANBOX)
-                            (required: Max Page)
+                            (optional: End Page)
                         f2 - Download by artist/creator id (FANBOX)
-                            (required: artist(digits only)/creator id, followed with Max Page)
+                            (required: artist(digits only)/creator ids separated by space,
+                             optional: end page)
                         f3 - Download by post id (FANBOX)
                             (required: post ids, separated with space)
                         f4 - Download from followed artists (FANBOX)
-                            (required: Max Page)
+                            (optional: End Page)
+                        f5 - Download from custom artist list (FANBOX)
+                            (optional: End page, path to list)
                         b - Batch Download from batch_job.json (experimental)
                         e - Export online bookmark
 			    (optional: Include Private Bookmark [y|n|o], filename)
@@ -297,11 +300,15 @@ Please refer run with `--help` for latest information.
 # config.ini
 ## [Authentication]
 ```
-username ==> Your pixiv username.
-password ==> Your pixiv password, in clear text!
+username ==> Your pixiv username. Needed for OAuth. Please make sure the combination
+             of username and password is valid in case of OAuth error.
+             If you get error 103, please try changing username from pixiv ID to email
+             address or the other way around.
+password ==> Your pixiv password, in clear text! Needed for OAuth. Please make sure 
+             the combination of username and password is valid in case of OAuth error.
 cookie   ==> Your cookies for pixiv login, will be automatically updated in the
              login.
-cookieFanbox  ==> Cookie for fanbox.cc
+cookieFanbox  ==> Cookie for fanbox.cc, normally no need to fill in.
 refresh_token ==> Used for OAuth refresh token to avoid relogin too many time.
                   Automatically generated upon succesful OAuth login.
 ```

--- a/readme.md
+++ b/readme.md
@@ -353,6 +353,8 @@ checkDBProcessHistory       ==> Each FANBOX post has a updated_date value, which
 				retrieved date, which means that the post has not been processed 
 				at all or changed since last time, the post would be skipped.
                             --> When this is 'False', posts will be processed anyways.
+listPathFanbox		    ==> The list file for fanbox creators. One creator per line.
+				Doesn't support custom path.
 ```
 ## [Network]
 ```


### PR DESCRIPTION
Implemented #804 
Main idea:
1. Added new option `listPathFanbox` in `PixivConfig.py`
2. Added support for custom list in `menu_fanbox_download_from_list`, and simply just read list from file, no storing in db or custom paths
3. Added support for multiple creator/user ids in `menu_fanbox_download_by_id`
4. Changed how the above functions uses options (changed from args to option.end_page instead)