### PR TITLE
Fix error in PixivHelper.py:173 - TypeError - expects String, not Int

### DIFF
--- a/PixivHelper.py
+++ b/PixivHelper.py
@@ -170,7 +170,7 @@ def make_filename(nameFormat: str,
 
     # sketch related
     if hasattr(artistInfo, "sketchArtistId"):
-        nameFormat = nameFormat.replace('%sketch_member_id%', artistInfo.sketchArtistId)
+        nameFormat = nameFormat.replace('%sketch_member_id%', str(artistInfo.sketchArtistId))
 
     # image related
     nameFormat = nameFormat.replace('%title%', replace_path_separator(imageInfo.imageTitle))


### PR DESCRIPTION
This bug was introduced in 648acd1135d4e68e1b9eecfd20ad169194f20fa6

Snippet from my logs running beta3

```
2020-10-18 20:25:55,224 - PixivUtil20201018-beta3 - ERROR - Exception: (<class 'TypeError'>, TypeError('replace() argument 2 must be str, not int'), <traceback object at 0x04430BA8>)
2020-10-18 20:25:55,225 - PixivUtil20201018-beta3 - ERROR - Traceback (most recent call last):
  File "PixivSketchHandler.pyc", line 59, in process_sketch_artists
  File "PixivSketchHandler.pyc", line 85, in download_post
  File "PixivHelper.pyc", line 173, in make_filename
TypeError: replace() argument 2 must be str, not int
```