### PR TITLE
Adding Filename option for Sketch and fixing dates and Unix filenames

### DIFF
--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -109,6 +109,8 @@ class PixivConfig():
         ConfigItem("Filename", "filenameMangaInfoFormat",
                    "%artist% (%member_id%)" + os.sep + "%urlFilename% - %title%",
                    restriction=lambda x: x is not None and len(x) > 0),
+        ConfigItem("Filename", "filenameFormatSketch", "%artist% (%member_id%)" + os.sep + "%urlFilename% - %title%",
+                   restriction=lambda x: x is not None and len(x) > 0),
         ConfigItem("Filename", "avatarNameFormat", ""),
         ConfigItem("Filename", "backgroundNameFormat", ""),
         ConfigItem("Filename", "tagsSeparator", ", "),

--- a/PixivHelper.py
+++ b/PixivHelper.py
@@ -37,17 +37,22 @@ from PixivModelFanbox import FanboxArtist, FanboxPost
 logger = None
 _config = None
 __re_manga_index = re.compile(r'_p(\d+)')
-__badchars__ = re.compile(r'''
-^$
-|\?
-|:
-|<
-|>
-|\|
-|\*
-|\"
-''', re.VERBOSE)
-
+__badchars__ = None
+if platform.system() == 'Windows':
+    __badchars__ = re.compile(r'''
+    ^$
+    |\?
+    |:
+    |<
+    |>
+    |\|
+    |\*
+    |\"
+    ''', re.VERBOSE)
+else:
+    __badchars__ = re.compile(r'''
+    ^$
+    ''', re.VERBOSE)
 
 def set_config(config):
     global _config

--- a/PixivImage.py
+++ b/PixivImage.py
@@ -407,8 +407,6 @@ class PixivImage (object):
         jsonInfo["Tags"] = self.imageTags
         jsonInfo["Image Mode"] = self.imageMode
         jsonInfo["Pages"] = self.imageCount
-        print(self.worksDateDateTime)
-        print(str(self.worksDateDateTime))
         jsonInfo["Date"] = str(self.worksDateDateTime)
         jsonInfo["Resolution"] = self.worksResolution
         jsonInfo["Tools"] = self.worksTools

--- a/PixivImage.py
+++ b/PixivImage.py
@@ -216,12 +216,12 @@ class PixivImage (object):
 
         # datetime, in utc
         # "createDate" : "2018-06-08T15:00:04+00:00",
-        self.worksDateDateTime = datetime_z.parse_datetime(str(root["createDate"]))
+        self.worksDateDateTime = datetime_z.parse_datetime(root["createDate"])
         # Issue #420
         if self._tzInfo is not None:
             self.worksDateDateTime = self.worksDateDateTime.astimezone(self._tzInfo)
 
-        tempDateFormat = self.dateFormat or "%Y.%m.%d %H:%M"  # 2018.2.27 12:31
+        tempDateFormat = self.dateFormat or "%Y%m%dT%H%M"     # 20180722T1231
         self.worksDate = self.worksDateDateTime.strftime(tempDateFormat)
 
         # resolution
@@ -375,7 +375,7 @@ class PixivImage (object):
         info.write("Tags          = " + ", ".join(self.imageTags) + "\r\n")
         info.write("Image Mode    = " + self.imageMode + "\r\n")
         info.write("Pages         = " + str(self.imageCount) + "\r\n")
-        info.write("Date          = " + str(self.worksDateDateTime) + "\r\n")
+        info.write("Date          = " + self.root["createDate"] + "\r\n")
         info.write("Resolution    = " + self.worksResolution + "\r\n")
         info.write("Tools         = " + self.worksTools + "\r\n")
         info.write("BookmarkCount = " + str(self.bookmark_count) + "\r\n")
@@ -407,7 +407,7 @@ class PixivImage (object):
         jsonInfo["Tags"] = self.imageTags
         jsonInfo["Image Mode"] = self.imageMode
         jsonInfo["Pages"] = self.imageCount
-        jsonInfo["Date"] = str(self.worksDateDateTime)
+        jsonInfo["Date"] = self.root["createDate"]
         jsonInfo["Resolution"] = self.worksResolution
         jsonInfo["Tools"] = self.worksTools
         jsonInfo["BookmarkCount"] = self.bookmark_count

--- a/PixivImage.py
+++ b/PixivImage.py
@@ -221,7 +221,7 @@ class PixivImage (object):
         if self._tzInfo is not None:
             self.worksDateDateTime = self.worksDateDateTime.astimezone(self._tzInfo)
 
-        tempDateFormat = self.dateFormat or "%m/%d/%y %H:%M"  # 2/27/2018 12:31
+        tempDateFormat = self.dateFormat or "%Y.%m.%d %H:%M"  # 2018.2.27 12:31
         self.worksDate = self.worksDateDateTime.strftime(tempDateFormat)
 
         # resolution
@@ -375,7 +375,7 @@ class PixivImage (object):
         info.write("Tags          = " + ", ".join(self.imageTags) + "\r\n")
         info.write("Image Mode    = " + self.imageMode + "\r\n")
         info.write("Pages         = " + str(self.imageCount) + "\r\n")
-        info.write("Date          = " + self.worksDate + "\r\n")
+        info.write("Date          = " + str(self.worksDateDateTime) + "\r\n")
         info.write("Resolution    = " + self.worksResolution + "\r\n")
         info.write("Tools         = " + self.worksTools + "\r\n")
         info.write("BookmarkCount = " + str(self.bookmark_count) + "\r\n")
@@ -407,7 +407,9 @@ class PixivImage (object):
         jsonInfo["Tags"] = self.imageTags
         jsonInfo["Image Mode"] = self.imageMode
         jsonInfo["Pages"] = self.imageCount
-        jsonInfo["Date"] = self.worksDate
+        print(self.worksDateDateTime)
+        print(str(self.worksDateDateTime))
+        jsonInfo["Date"] = str(self.worksDateDateTime)
         jsonInfo["Resolution"] = self.worksResolution
         jsonInfo["Tools"] = self.worksTools
         jsonInfo["BookmarkCount"] = self.bookmark_count

--- a/PixivSketchHandler.py
+++ b/PixivSketchHandler.py
@@ -82,7 +82,7 @@ def download_post(caller, config, post):
     referer = f"https://sketch.pixiv.net/items/{post.imageId}"
     current_page = 0
     for url in post.imageUrls:
-        filename = PixivHelper.make_filename(config.filenameFormat,
+        filename = PixivHelper.make_filename(config.filenameFormatSketch,
                                             post,
                                             artistInfo=post.artist,
                                             tagsSeparator=config.tagsSeparator,


### PR DESCRIPTION
__badchars__ were ruining folder / picture names
Fixed default date format, which was creating folders and in a bad format
Changed the json / txt date to be independent of the date format used.