### PR TITLE
Fix bug of header

### DIFF
--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -159,7 +159,7 @@ class PixivBrowser(mechanize.Browser):
         self.addheaders = [('User-agent', config.useragent)]
 
         # force utf-8, fix issue #184
-        self.addheaders = [('Accept-Charset', 'utf-8')]
+        self.addheaders += [('Accept-Charset', 'utf-8')]
 
         socket.setdefaulttimeout(config.timeout)
 


### PR DESCRIPTION
PixivBrowser.addheaders is a list default is [('User-agent', 'Python-urllib/<python_version>')] inital in [mechanize](https://github.com/python-mechanize/mechanize/blob/v0.4.5/mechanize/_urllib2_fork.py#L344).

The  'Accept-Charset' assignment (line 162) overwrite the 'user-agent' assignment (line 159).
The bug let receive the 403 error when opening the index of Pixiv.