### PR TITLE
Add config option to not download the cover for fanbox

### DIFF
--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -152,6 +152,7 @@ class PixivConfig():
         ConfigItem("FANBOX", "minImageCountForNonArticle", 3),
         ConfigItem("FANBOX", "useAbsolutePathsInHtml", False),
         ConfigItem("FANBOX", "downloadCoverWhenRestricted", False),
+        ConfigItem("FANBOX", "downloadCover", True),
         ConfigItem("FANBOX", "checkDBProcessHistory", False),
         ConfigItem("FANBOX", "listPathFanbox", "listfanbox.txt"),
 

--- a/PixivFanboxHandler.py
+++ b/PixivFanboxHandler.py
@@ -87,7 +87,7 @@ def process_fanbox_post(caller, config, post, artist):
         if not post.is_restricted and not flag_processed:
             br.fanboxUpdatePost(post)
 
-        if ((not post.is_restricted) or config.downloadCoverWhenRestricted) and (not flag_processed):
+        if ((not post.is_restricted) or config.downloadCoverWhenRestricted) and (not flag_processed) and config.downloadCover:
             # cover image
             if post.coverImageUrl is not None:
                 # fake the image_url for filename compatibility, add post id and pagenum


### PR DESCRIPTION
Add new config option to skip downloading cover images from fanbox. In my experience, the cover is usually either a static image for all posts, or a crop of the protected image. Default is still true to preserve the original behavior.