### PR TITLE
Fix #873 and #886

### DIFF
--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -870,7 +870,7 @@ class PixivBrowser(mechanize.Browser):
         else:
             raise ValueError(f"Invalid via argument {via}")
 
-        def fanboxGetArtistById(self, artist_id, for_suspended=False):
+    def fanboxGetArtistById(self, artist_id, for_suspended=False):
         self.fanbox_is_logged_in()
         if re.match(r"^\d+$", artist_id):
             id_type = "userId"

--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -870,7 +870,7 @@ class PixivBrowser(mechanize.Browser):
         else:
             raise ValueError(f"Invalid via argument {via}")
 
-    def fanboxGetArtistById(self, artist_id):
+        def fanboxGetArtistById(self, artist_id, for_suspended=False):
         self.fanbox_is_logged_in()
         if re.match(r"^\d+$", artist_id):
             id_type = "userId"
@@ -910,11 +910,13 @@ class PixivBrowser(mechanize.Browser):
 
             # Issue #827, less efficient call, but it can avoid oAuth issue
             pixivArtist = PixivArtist(artist.artistId)
-            self.getMemberInfoWhitecube(artist.artistId, pixivArtist)
-            # (pixivArtist, _) = self.getMemberPage(artist.artistId)
 
-            artist.artistName = pixivArtist.artistName
-            artist.artistToken = pixivArtist.artistToken
+            if not for_suspended:
+                self.getMemberInfoWhitecube(artist.artistId, pixivArtist)
+                # (pixivArtist, _) = self.getMemberPage(artist.artistId)
+
+                artist.artistName = pixivArtist.artistName
+                artist.artistToken = pixivArtist.artistToken
             return artist
         else:
             raise PixivException("Id does not exist", errorCode=PixivException.USER_ID_NOT_EXISTS)

--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -908,11 +908,10 @@ class PixivBrowser(mechanize.Browser):
                                   js_body["creatorId"],
                                   tzInfo=_tzInfo)
 
-            # Issue #827, less efficient call, but it can avoid oAuth issue
-            pixivArtist = PixivArtist(artist.artistId)
-
             if not for_suspended:
+                pixivArtist = PixivArtist(artist.artistId)
                 self.getMemberInfoWhitecube(artist.artistId, pixivArtist)
+                # Issue #827, less efficient call, but it can avoid oAuth issue
                 # (pixivArtist, _) = self.getMemberPage(artist.artistId)
 
                 artist.artistName = pixivArtist.artistName

--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -909,9 +909,9 @@ class PixivBrowser(mechanize.Browser):
                                   tzInfo=_tzInfo)
 
             # Issue #827, less efficient call, but it can avoid oAuth issue
-            # pixivArtist = PixivArtist(artist.artistId)
-            # self.getMemberInfoWhitecube(artist.artistId, pixivArtist)
-            (pixivArtist, _) = self.getMemberPage(artist.artistId)
+            pixivArtist = PixivArtist(artist.artistId)
+            self.getMemberInfoWhitecube(artist.artistId, pixivArtist)
+            # (pixivArtist, _) = self.getMemberPage(artist.artistId)
 
             artist.artistName = pixivArtist.artistName
             artist.artistToken = pixivArtist.artistToken

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -767,8 +767,8 @@ def menu_fanbox_download_by_post_id(op_is_valid, args, options):
         post_ids = args
     else:
         post_ids = input("Post ids = ").rstrip("\r")
+        post_ids = PixivHelper.get_ids_from_csv(post_ids)
 
-    post_ids = PixivHelper.get_ids_from_csv(post_ids)
     for post_id in post_ids:
         try:
             post = __br__.fanboxGetPostById(post_id)


### PR DESCRIPTION
For #873 
Thanks to @Nandaka for his update in dbmanager to store creator tokens in db in the following submission.
https://github.com/Nandaka/PixivUtil2/commit/200556df5a30cb605601c359b21371340c474512

1. Added a new parameter `for_suspended` for browser method `fanboxGetArtistById` with default value False to not obtain information from pixiv API when it was False
2. Changed back to the old pixiv API to retrieve creator information from pixiv
3. In `process_fanbox_artist_by_id` of `PixivFanboxHandler`  added logic to use data from db if creator is suspended on pixiv
(if creator doesn't have a fanbox page, the error should be `USER_ID_NOT_EXISTS`. I have not encountered the situation where a creator is only suspended on fanbox so I just made it so currently.)

since dbmanager is not accessible in browser, so the codes are kinda messy....

For #886:
Added another 4-space indent before the line `post_ids = PixivHelper.get_ids_from_csv(post_ids) ` to make it only be called when ids are given through keyboard input instead of command line arguments.