### PR TITLE
Fix

### DIFF
--- a/PixivDownloadHandler.py
+++ b/PixivDownloadHandler.py
@@ -206,10 +206,10 @@ def download_image(caller,
                 # write to downloaded lists
                 if caller.start_iv or config.createDownloadLists:
                     dfile = codecs.open(caller.dfilename, 'a+', encoding='utf-8')
-                    dfile.write(filename + "\n")
+                    dfile.write(filename_save + "\n")
                     dfile.close()
 
-                return (PixivConstant.PIXIVUTIL_OK, filename)
+                return (PixivConstant.PIXIVUTIL_OK, filename_save)
 
             except urllib.error.HTTPError as httpError:
                 PixivHelper.print_and_log('error', f'[download_image()] HTTP Error: {httpError} at {url}')

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -757,6 +757,13 @@ def menu_fanbox_download_from_list(op_is_valid, via, args, options):
                                                            artist_id,
                                                            end_page,
                                                            title_prefix=f"{index} of {len(ids)}")
+        except KeyboardInterrupt:
+            choice = input("Keyboard Interrupt detected, continue to next artist (Y/N)").rstrip("\r")
+            if choice.upper() == 'N':
+                PixivHelper.print_and_log("info", f"Artist id: {artist_id}, processing aborted")
+                break
+            else:
+                continue
         except PixivException as pex:
             PixivHelper.print_and_log("error", f"Error processing FANBOX Artist in {via_type} list: {artist_id} ==> {pex.message}")
 
@@ -800,11 +807,21 @@ def menu_fanbox_download_by_id(op_is_valid, args, options):
     PixivHelper.print_and_log('info', f"Member IDs: {member_ids}")
 
     for index, member_id in enumerate(member_ids, start=1):
-        PixivFanboxHandler.process_fanbox_artist_by_id(sys.modules[__name__],
-                                                       __config__,
-                                                       member_id,
-                                                       end_page,
-                                                       title_prefix=f"{index} of {len(member_ids)}")
+        try:
+            PixivFanboxHandler.process_fanbox_artist_by_id(sys.modules[__name__],
+                                                           __config__,
+                                                           member_id,
+                                                           end_page,
+                                                           title_prefix=f"{index} of {len(member_ids)}")
+        except KeyboardInterrupt:
+            choice = input("Keyboard Interrupt detected, continue to next artist (Y/N)").rstrip("\r")
+            if choice.upper() == 'N':
+                PixivHelper.print_and_log("info", f"Artist id: {member_id}, processing aborted")
+                break
+            else:
+                continue
+        except PixivException as pex:
+            PixivHelper.print_and_log("error", f"Error processing FANBOX Artist: {member_id} ==> {pex.message}")
 
 
 def menu_sketch_download_by_artist_id(opisvalid, args, options):


### PR DESCRIPTION
Mainly:
1. Fixed when downloading fails to be saved to desired path but under the folder of PixivUtil2, desired path instead of actual path is saved to db, as spoken of in https://github.com/Nandaka/PixivUtil2/issues/889#issuecomment-761727105 under issue #889 
2. Optimized logic for FANBOX artists who are suspended on pixiv, as in #896 , also fixed a bug I caused and didn't realize.

Did not implement the `custom bad characters` idea, because of laziness, and I have to agree with @byjtje , that it's not PixivUtil2's problem, and it could be solved with other tools, like batch renaming tools.
I am not so sure about the actual file path thing... but whatever, I never use that column or related menus.