### PR TITLE
Add config option to ignore beta versions

### DIFF
--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -60,6 +60,7 @@ class PixivConfig():
         ConfigItem("Network", "retryWait", 5),
         ConfigItem("Network", "downloadDelay", 2),
         ConfigItem("Network", "checkNewVersion", True),
+        ConfigItem("Network", "notifyBetaVersion", True),
         ConfigItem("Network", "openNewVersion", True),
         ConfigItem("Network", "enableSSLVerification", True),
 

--- a/PixivHelper.py
+++ b/PixivHelper.py
@@ -1038,6 +1038,8 @@ def check_version(br, config=None):
     latest_version_int = int(latest_version_full[0][0])
     curr_version_int = int(re.findall(r"(\d+)", PixivConstant.PIXIVUTIL_VERSION)[0])
     is_beta = True if latest_version_full[0][1].find("beta") >= 0 else False
+    if is_beta and not config.notifyBetaVersion:
+        return
     url = "https://github.com/Nandaka/PixivUtil2/releases"
     if latest_version_int > curr_version_int:
         if is_beta:

--- a/readme.md
+++ b/readme.md
@@ -414,6 +414,9 @@ Please refer run with `--help` for latest information.
 - checkNewVersion
 
   Set to `True` to check new releases in github.
+- notifyBetaVersion
+
+  Set to `False` to ignore beta releases.
 - openNewVersion
 
   Set to `False` to disable opening new releases in browser.


### PR DESCRIPTION
Small quality of life enhancement allowing the user to ignore beta versions should they choose to. Default setting is to continue receiving beta versions.