### PR TITLE
Show URL for oauth

### DIFF
--- a/PixivOAuthBrowser.py
+++ b/PixivOAuthBrowser.py
@@ -63,6 +63,7 @@ def login():
 
     print(Style.BRIGHT + Fore.YELLOW + "Instructions: " + Style.RESET_ALL)
     print("1. This will open a new browser to login to Pixiv site to get the code.")
+    print("1b. In case the browser will not open, or you are using an headless server, use this link: " + f"{LOGIN_URL}?{urlencode(login_params)}")
     print("2. Open dev console " + Fore.YELLOW + "(F12)" + Style.RESET_ALL + " and switch to network tab." + Style.RESET_ALL)
     print("3. Enable persistent logging (" + Fore.YELLOW + "\"Preserve log\"" + Style.RESET_ALL + "). " + Style.RESET_ALL)
     print("4. Type into the filter field: '" + Fore.YELLOW + "callback?" + Style.RESET_ALL + "'." + Style.RESET_ALL)


### PR DESCRIPTION
If the tool is used on an headless server, it will not open any new browser window for obvious reasons.
Adding the point 1.b allow the user to manually copy and paste it on their computer browser.