### PR TITLE
Change the shebang in PixivUtil2.py to python3

### DIFF
--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # flake8: noqa:E501,E128,E127
 import codecs


### PR DESCRIPTION
I am using PixivUtil2 on my Mac, and I think it would be nice to change the shebang to python3 so that Unix users can run the script like `./PixivUtil2.py`.

---

### Steps to reproduce

1. Run `./PixivUtil2.py`.

#### What should happen?

PixivUtil2 runs just fine.

#### What has happened?

Because of the wrong shebang, the file is executed by Python 2, thus failing to work.

---

Best regards.