### PR TITLE
Allows Post Processing to accept command arguments

### DIFF
--- a/PixivDownloadHandler.py
+++ b/PixivDownloadHandler.py
@@ -7,6 +7,7 @@ import sys
 import time
 import traceback
 import urllib
+import shlex
 
 import mechanize
 
@@ -235,7 +236,7 @@ def download_image(caller,
                 if config.enablePostProcessing and len(config.postProcessingCmd) > 0:
                     cmd = config.postProcessingCmd.replace("%filename%", filename_save)
                     PixivHelper.print_and_log('info', f'Running post processing command: {cmd}')
-                    subprocess.Popen(cmd, startupinfo=None)
+                    subprocess.Popen(shlex.split(cmd), startupinfo=None)
 
                 return (PixivConstant.PIXIVUTIL_OK, filename_save)
 


### PR DESCRIPTION
 Fixes #978
The Post Processing command uses `subprocess.Popen(cmd)` to run the command. Popen requires the command to be formatted as a list for aguments to be accepted, or for `Shell=True` to be enabled.

This is not the case, the command is passed through as a single string.
https://github.com/Nandaka/PixivUtil2/blob/49f77438390f5f553813aad2ca59b512fc97a16b/PixivDownloadHandler.py#L234-L238

[The documentation for Popen](https://docs.python.org/3/library/subprocess.html#popen-constructor) illustrates how to use `shlex.split` to split the arguments automatically.
This seems to work well

https://github.com/Baa14453/PixivUtil2/blob/4f41001a171d660c88140c4d983fceb2a67dd935/PixivDownloadHandler.py#L236-L239


