### PR TITLE
Adds support for .XMP sidecar files.

### DIFF
--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -92,6 +92,8 @@ class PixivConfig():
         ConfigItem("Settings", "RawJSONFilter",
                    "id,title,description,alt,userIllusts,storableTags,zoneConfig,extraData,comicPromotion,fanboxPromotion"),
         ConfigItem("Settings", "includeSeriesJSON", False),
+        ConfigItem("Settings", "writeImageXMP", False),
+        ConfigItem("Settings", "writeImageXMPPerImage", False),
         ConfigItem("Settings", "verifyImage", False),
         ConfigItem("Settings", "writeUrlInDescription", False),
         ConfigItem("Settings", "urlBlacklistRegex", ""),

--- a/PixivDownloadHandler.py
+++ b/PixivDownloadHandler.py
@@ -7,6 +7,7 @@ import sys
 import time
 import traceback
 import urllib
+import shlex
 
 import mechanize
 
@@ -235,7 +236,7 @@ def download_image(caller,
                 if config.enablePostProcessing and len(config.postProcessingCmd) > 0:
                     cmd = config.postProcessingCmd.replace("%filename%", filename_save)
                     PixivHelper.print_and_log('info', f'Running post processing command: {cmd}')
-                    subprocess.Popen(cmd, startupinfo=None)
+                    subprocess.Popen(shlex.split(cmd), startupinfo=None)
 
                 return (PixivConstant.PIXIVUTIL_OK, filename_save)
 

--- a/PixivImage.py
+++ b/PixivImage.py
@@ -7,7 +7,6 @@ import re
 import shutil
 import urllib
 import zipfile
-import pyexiv2
 from collections import OrderedDict
 from datetime import datetime
 from typing import List, Tuple
@@ -439,6 +438,7 @@ class PixivImage (object):
             info.close()
 
     def WriteXMP(self, filename):
+        import pyexiv2
         info = None
         try:
             # Issue #421 ensure subdir exists.

--- a/PixivImageHandler.py
+++ b/PixivImageHandler.py
@@ -273,7 +273,25 @@ def process_image(caller,
                         PixivHelper.print_and_log('error', f'Error when download_image(), giving up url: {img}')
                     PixivHelper.print_and_log(None, '')
 
-            if config.writeImageInfo or config.writeImageJSON:
+                    if config.writeImageXMPPerImage:
+                        filename_info_format = config.filenameInfoFormat or config.filenameFormat
+                        # Issue #575
+                        if image.imageMode == 'manga':
+                            filename_info_format = config.filenameMangaInfoFormat or config.filenameMangaFormat or filename_info_format
+                        info_filename = PixivHelper.make_filename(filename_info_format,
+                                                                image,
+                                                                tagsSeparator=config.tagsSeparator,
+                                                                tagsLimit=config.tagsLimit,
+                                                                fileUrl=url,
+                                                                appendExtension=False,
+                                                                bookmark=bookmark,
+                                                                searchTags=search_tags,
+                                                                useTranslatedTag=config.useTranslatedTag,
+                                                                tagTranslationLocale=config.tagTranslationLocale)
+                        info_filename = PixivHelper.sanitize_filename(info_filename, target_dir)
+                        image.WriteXMP(info_filename + ".xmp")
+
+            if config.writeImageInfo or config.writeImageJSON or config.writeImageXMP:
                 filename_info_format = config.filenameInfoFormat or config.filenameFormat
                 # Issue #575
                 if image.imageMode == 'manga':
@@ -305,6 +323,8 @@ def process_image(caller,
                     # trim _pXXX
                     json_filename = re.sub(r'_p?\d+$', '', json_filename)
                     image.WriteSeriesData(image.seriesNavData['seriesId'], caller.__seriesDownloaded, json_filename + ".json")
+                if config.writeImageXMP and not config.writeImageXMPPerImage:
+                    image.WriteXMP(info_filename + ".xmp")
 
             if image.imageMode == 'ugoira_view':
                 if config.writeUgoiraInfo:

--- a/readme.md
+++ b/readme.md
@@ -946,6 +946,7 @@ http://www.pixiv.net/member_illust.php?id=123456
 - fireattack
 - Jared Shields
 - DenDen047
+- Baa
 
 ** If I forget someone, please send me a pull request with the commit/merge id.
 

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@
 
 - Dependent software
   - FFmpeg (https://www.ffmpeg.org/) - used for converting ugoira to video.
+  - Exiv2 (https://exiv2.org/) - used for writing XMP metadata (if enabled).
 
 # Capabilities:
 - Download by member_id

--- a/readme.md
+++ b/readme.md
@@ -509,6 +509,12 @@ Please refer run with `--help` for latest information.
 
   Set to `True` to export the series information to JSON.
   The filename is following `filenameSeriesJSON` + .json.
+- writeImageXMP
+
+  Set to `True` to export the image information to a .XMP sidecar file, this does not add XMP metadata to the image header.
+- writeImageXMPPerImage
+
+  Set to `True` to export the image information to a .XMP sidecar file, one per image in the album. The data contained within the file is the same but some software requires matching file names to detect the metadata. If set to `True`, then `writeImageXMP` is ignored.
 - verifyimage
 
   Do image and zip checking after download. Set the value to `True` to enable.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ PySocks>=1.7.1
 # apng>=0.3.3
 colorama>=0.4.4
 cloudscraper>=1.2.58
-py3exiv2>=0.9.3
+# py3exiv2>=0.9.3 # Required for writeImageXMP.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ PySocks>=1.7.1
 # apng>=0.3.3
 colorama>=0.4.4
 cloudscraper>=1.2.58
+py3exiv2>=0.9.3


### PR DESCRIPTION
Because actually adding XMP metadata feels dirty, some software supports .XMP sidecar files, such as DigiKam.

A second option adds duplicate sidecar files for every single image in the album. It's messy but required for some software... or for DigiKam anyway.

XMP works on [a number](https://www.exiftool.org/TagNames/XMP.html) of pre-defined 'namespaces' that become the metadata standards.
I've used the namespace of [Dublin Core](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/) because it's quite popular, some image attributes fit well.
https://github.com/Baa14453/PixivUtil2/blob/42f4e66fad59e190cc1d69bc65c90f6b95220895/PixivImage.py#L460-L465


The ones that did not go into the custom PIxiv NameSpace.
The custom namespace serves no use unless someone manually adds support to their software, but it wasn't hard to do so I thought I'd add the remaining details into it.
https://github.com/Baa14453/PixivUtil2/blob/42f4e66fad59e190cc1d69bc65c90f6b95220895/PixivImage.py#L470-L484

It's a limitation of this library that Custom Namespaces can only contain Strings, so the lists relevant such as Description URLs have been merged into a string, split by commas.
https://github.com/Baa14453/PixivUtil2/blob/42f4e66fad59e190cc1d69bc65c90f6b95220895/PixivImage.py#L484

This section duplicates some code for the per-image setup.
https://github.com/Baa14453/PixivUtil2/blob/42f4e66fad59e190cc1d69bc65c90f6b95220895/PixivImageHandler.py#L276-L292

It's another limitation of this library that it cannot create metadata out of thin air, but it can open an almost empty XMP file and add more metadata, so this bit creates a quick template for the library to open.
https://github.com/Baa14453/PixivUtil2/blob/42f4e66fad59e190cc1d69bc65c90f6b95220895/PixivImage.py#L452-L458

### Pictures
The files
![image](https://user-images.githubusercontent.com/9057997/125205390-e2dd3480-e279-11eb-842f-bc2a34d605a3.png)

Success in Digikam
![image](https://user-images.githubusercontent.com/9057997/125205401-f6889b00-e279-11eb-89ff-0947e824e4e0.png)

### Example XMP file
```xmp
<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="XMP Core 4.4.0-Exiv2">
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
  <rdf:Description rdf:about=""
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:pixiv="http://pixiv.com/"
   dc:source="http://www.pixiv.net/en/artworks/{self.imageId}"
   pixiv:image_id="91155317"
   pixiv:artist_id="2033916"
   pixiv:image_mode="manga"
   pixiv:pages="9"
   pixiv:resolution="Multiple images: 9P"
   pixiv:bookmark_count="1773">
   <dc:creator>
    <rdf:Seq>
     <rdf:li>あすてろid</rdf:li>
    </rdf:Seq>
   </dc:creator>
   <dc:title>
    <rdf:Alt>
     <rdf:li xml:lang="x-default">CORNEA</rdf:li>
    </rdf:Alt>
   </dc:title>
   <dc:subject>
    <rdf:Bag>
     <rdf:li>original</rdf:li>
     <rdf:li>scenery</rdf:li>
     <rdf:li>ruins</rdf:li>
    </rdf:Bag>
   </dc:subject>
   <dc:date>
    <rdf:Seq>
     <rdf:li>2021-07-10 15:01:08+00:00</rdf:li>
    </rdf:Seq>
   </dc:date>
  </rdf:Description>
 </rdf:RDF>
</x:xmpmeta>
<?xpacket end="w"?>
```