### PR TITLE
Correct shape of BOM in Downloaded List

### DIFF
--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1305,7 +1305,7 @@ def main():
     if start_iv or __config__.createDownloadLists:
         if not os.path.isfile(dfilename) or os.path.getsize(dfilename) == 0:
             dfile = codecs.open(dfilename, 'a+', encoding='utf-8')
-            dfile.write(u'\ufeff')
+            dfile.write(u'\uefbbbf')
             dfile.close()
 
     # Yavos: adding IrfanView-Handling


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8, current one is from UTF-16
Doesn't help my other use case, but at least now it's according to specification. That I should have read first thing.