### PR TITLE
Update WriteXMP feature to use pyexiv2 only

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ PySocks>=1.7.1
 # apng>=0.3.3
 colorama>=0.4.4
 cloudscraper>=1.2.58
-# py3exiv2>=0.9.3 # Required for writeImageXMP.
+# pyexiv2>=2.7.0 # Required for writeImageXMP.


### PR DESCRIPTION
Pyexiv2 is a more up-to-date Exiv2 wrapper that supports both Windows and Linux.
This removes the remaining support for the previous package Py3exiv2 which only supported Linux.

Fixes #1040

Testing on Fresh install of Ubuntu _and_ Windows 11 this time, in Windows you need to install the VCC Redistributable for Exiv2 library to work, see full installation troubleshooting here: https://github.com/LeoHsiao1/pyexiv2/blob/master/docs/Tutorial.md#installation