### PR TITLE
Remove Exiv2 from dependent software.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,6 @@
 
 - Dependent software
   - FFmpeg (https://www.ffmpeg.org/) - used for converting ugoira to video.
-  - Exiv2 (https://exiv2.org/) - used for writing XMP metadata (if enabled).
 
 # Capabilities:
 - Download by member_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ PySocks>=1.7.1
 # apng>=0.3.3
 colorama>=0.4.4
 cloudscraper>=1.2.58
-# py3exiv2>=0.9.3 # Required for writeImageXMP.
+# pyexiv2>=2.7.0 # Required for writeImageXMP.


### PR DESCRIPTION
No longer required to be installed separately, the new Python library comes with the dll