### PR TITLE
Adds feature to strip HTML from captions

### DIFF
--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -618,7 +618,8 @@ class PixivBrowser(mechanize.Browser):
                                    tzInfo=_tzInfo,
                                    manga_series_order=manga_series_order,
                                    manga_series_parent=manga_series_parent,
-                                   writeRawJSON=self._config.writeRawJSON)
+                                   writeRawJSON=self._config.writeRawJSON,
+                                   stripHTMLTagsFromCaption=self._config.stripHTMLTagsFromCaption)
 
                 if image.imageMode == "ugoira_view":
                     ugoira_meta_url = f"https://www.pixiv.net/ajax/illust/{image_id}/ugoira_meta"

--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -96,6 +96,7 @@ class PixivConfig():
         ConfigItem("Settings", "writeImageXMPPerImage", False),
         ConfigItem("Settings", "verifyImage", False),
         ConfigItem("Settings", "writeUrlInDescription", False),
+        ConfigItem("Settings", "stripHTMLTagsFromCaption", False),
         ConfigItem("Settings", "urlBlacklistRegex", ""),
         ConfigItem("Settings", "dbPath", ""),
         ConfigItem("Settings", "setLastModified", True),

--- a/PixivImage.py
+++ b/PixivImage.py
@@ -91,7 +91,8 @@ class PixivImage (object):
                  tzInfo=None,
                  manga_series_order=-1,
                  manga_series_parent=None,
-                 writeRawJSON=False):
+                 writeRawJSON=False,
+                 stripHTMLTagsFromCaption=False):
         self.artist = parent
         self.fromBookmark = fromBookmark
         self.bookmark_count = bookmark_count
@@ -102,6 +103,7 @@ class PixivImage (object):
         self.descriptionUrlList = []
         self._tzInfo = tzInfo
         self.tags = list()
+        self.stripHTMLTagsFromCaption = stripHTMLTagsFromCaption
         # only for manga series
         self.manga_series_order = manga_series_order
         self.manga_series_parent = manga_series_parent
@@ -253,6 +255,10 @@ class PixivImage (object):
                 self.descriptionUrlList.append(link_str)
         parsed.decompose()
         del parsed
+
+        # Strip HTML tags from caption once they have been collected by the above statement.
+        if self.stripHTMLTagsFromCaption:
+            self.imageCaption = BeautifulSoup(self.imageCaption, "lxml").text
 
     def ParseUgoira(self, page):
         # preserve the order

--- a/readme.md
+++ b/readme.md
@@ -526,6 +526,9 @@ Please refer run with `--help` for latest information.
 - writeUrlInDescription
 
   Write all url found in the image description to a text file. Set to `True` to enable. The list will be saved to to the application folder as url_list_<timestamp>.txt
+- stripHTMLTagsFromCaption
+
+  Remove all HTML tags and their contents from the image caption/description when writing metadata to files. The contents of any links will be lost, so consider enabling writeUrlInDescription to retain them.
 - urlBlacklistRegex
   
   Used to filter out the url in the description using regular expression.

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
 
 - Dependent software
   - FFmpeg (https://www.ffmpeg.org/) - used for converting ugoira to video.
-  - Exiv2 (https://exiv2.org/) - used for writing XMP metadata (if enabled).
+  - VC++ Redistributable (https://visualstudio.microsoft.com/downloads/#microsoft-visual-c-redistributable-for-visual-studio-2019) - Needed for pyexiv2 to write XMP metadata (if enabled).
 
 # Capabilities:
 - Download by member_id

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
 
 - Dependent software
   - FFmpeg (https://www.ffmpeg.org/) - used for converting ugoira to video.
-  - VC++ Redistributable (https://visualstudio.microsoft.com/downloads/#microsoft-visual-c-redistributable-for-visual-studio-2019) - Needed for pyexiv2 to write XMP metadata (if enabled).
+  - [VC++ Redistributable](https://visualstudio.microsoft.com/downloads/#microsoft-visual-c-redistributable-for-visual-studio-2019) - Needed for pyexiv2 to write XMP metadata in Windows (if enabled).
 
 # Capabilities:
 - Download by member_id


### PR DESCRIPTION
Because Pixiv allows some formatting in image descriptions, the HTML tags remain and it can mess up the formatting of some descriptions in image software e.g:

![image](https://user-images.githubusercontent.com/9057997/140617572-bce431b5-2be2-465e-b2bd-c9d93da9a9f4.png)

With the stripHTMLTagsFromCaption enabled, the HTML tags are removed using BeautifulSoup:
![image](https://user-images.githubusercontent.com/9057997/140617753-d33711d8-9e31-436f-9286-226277e77131.png)

This does mean that some data might be lost .e.g the actual URL because it's inside the <a> tag, for URLs though I made sure this is collected by `writeUrlInDescription` **before** they are removed by `stripHTMLTagsFromCaption` so they are available in the rest of the metadata.

![image](https://user-images.githubusercontent.com/9057997/140617819-445ec8f3-a2d4-48bc-b5b1-b6a1fa472f25.png)

Also I've removed Exiv2 from dependent software as it's not needed with the new Pyexiv2 library implemented earlier, but Visual Studio C++ Redistributable is required and is not installed on Windows by default.