### PR TITLE
Replace lxml with html.parser

### DIFF
--- a/PixivImage.py
+++ b/PixivImage.py
@@ -258,7 +258,7 @@ class PixivImage (object):
 
         # Strip HTML tags from caption once they have been collected by the above statement.
         if self.stripHTMLTagsFromCaption:
-            self.imageCaption = BeautifulSoup(self.imageCaption, "lxml").text
+            self.imageCaption = BeautifulSoup(self.imageCaption, "html.parser").text
 
     def ParseUgoira(self, page):
         # preserve the order

--- a/PixivImage.py
+++ b/PixivImage.py
@@ -258,7 +258,12 @@ class PixivImage (object):
 
         # Strip HTML tags from caption once they have been collected by the above statement.
         if self.stripHTMLTagsFromCaption:
-            self.imageCaption = BeautifulSoup(self.imageCaption, "html.parser").text
+            self.imageCaption = BeautifulSoup(self.imageCaption, "html5lib")
+            # Replace <br> with whitespace to help preserve formatting.
+            self.imageCaption.br.replace_with(" ")
+            # Replace <a href="https://meow.com">Meow</a> with  "Meow (meow.com)" to help prevent data loss while sanitising tags.
+            self.imageCaption.a.replace_with(f"{self.imageCaption.a.string} ({self.imageCaption.a.contents[0]})")
+            self.imageCaption = self.imageCaption.text
 
     def ParseUgoira(self, page):
         # preserve the order


### PR DESCRIPTION
I didn't notice that lxml required an external dependency.
Rather than add it, I've just replaced it with the native html.parser, apparently it's slightly slower but shouldn't matter for this.