### PR TITLE
Fixes my bad on past attempt to deal with BOM

### DIFF
--- a/PixivDownloadHandler.py
+++ b/PixivDownloadHandler.py
@@ -248,7 +248,7 @@ def download_image(caller,
 
                 # write to downloaded lists
                 if caller.start_iv or config.createDownloadLists:
-                    dfile = codecs.open(caller.dfilename, 'a+', encoding='utf-8')
+                    dfile = codecs.open(caller.dfilename, 'a+', encoding=caller.platform_encoding)
                     dfile.write(filename_save + "\n")
                     dfile.close()
 

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -65,6 +65,10 @@ if platform.system() == "Windows":
         return pw
 
     getpass.getpass = win_getpass_with_mask
+    platform_encoding = 'utf-8-sig'
+else:
+    platform_encoding = 'utf-8'
+
 
 script_path = PixivHelper.module_path()
 
@@ -1623,13 +1627,6 @@ def main():
     if not os.path.exists(directory):
         os.makedirs(directory)
         __log__.info('Creating directory: %s', directory)
-
-    # write BOM
-    if start_iv or __config__.createDownloadLists:
-        if not os.path.isfile(dfilename) or os.path.getsize(dfilename) == 0:
-            dfile = codecs.open(dfilename, 'a+', encoding='utf-8')
-            dfile.write(u'\uefbbbf')
-            dfile.close()
 
     # Yavos: adding IrfanView-Handling
     start_irfan_slide = False


### PR DESCRIPTION
Previously the "write bom segment" code wrote garbage instead of actual byte order mark.
With this I remove a not-invented-here fix for this whole irfan view problem and add a system-dependent definition for downloaded list file encoding, so on Windows there would no need to fix BOM when I want to see all my fresh pictures and on Linux there's no need to remove BOM for scripting with Downloaded file.