### PR TITLE
Add a separator in temp folder cmd for windows (fix #1132)

### DIFF
--- a/PixivHelper.py
+++ b/PixivHelper.py
@@ -1135,7 +1135,7 @@ def check_image_encoding(directory: str) -> None:
 
     # Append every images to their corresponding number of bit depth in a dictionnary
     for filename in os.listdir(directory):
-        f = os.path.join(directory, filename)
+        f = os.path.join(directory, os.sep, filename)
         # checking if it is a file
         if ((os.path.isfile(f)) and (f.endswith((".jpg", ".png")))):
             fp = None


### PR DESCRIPTION
The line os.path.join apparently does not work with adding a os.sep in between filepath (only occurs on Windows)