### PR TITLE
Fixes Byte Order Mark in Downloaded file list, again.

### DIFF
--- a/PixivDownloadHandler.py
+++ b/PixivDownloadHandler.py
@@ -245,6 +245,14 @@ def download_image(caller,
                         raise
                 else:
                     PixivHelper.print_and_log('info', ' done.')
+                
+                # codecs.open is stateless, so if platform_encoding == utf-8-sig each new line starts from utf-8-sig
+                # this is bad and I feel bad
+
+                if os.path.isfile(caller.dfilename):
+                    dfile_encoding = 'utf-8'
+                else:
+                    dfile_encoding = caller.platform_encoding
 
                 # write to downloaded lists
                 if caller.start_iv or config.createDownloadLists:


### PR DESCRIPTION
codecs.open is stateless, so simple way doesn't work and we need to deal
with state, or we get a BOM on each newline. This is suboptimal and forces
more postprocessing of Downloaded file list for correct result.

All of this code could be deleted if irfan fixes it's unicode file bug.
Alas, bug persists in all text files irfan opens, including it's config.
So fix is unlikely. :^(

Note to self: test not only on one line, but on multiple lines.