### PR TITLE
fix ugoira when using ffmpeg executable for Windows path on all distribution (issue #1141)

### DIFF
--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -179,8 +179,8 @@ class PixivConfig():
         ConfigItem("FFmpeg", "webpCodec", "libwebp"),
         ConfigItem("FFmpeg", "webpParam", "-row-mt 1 -lossless 0 -q:v 90 -loop 0 -vsync 2 -r 999"),
         ConfigItem("FFmpeg", "gifParam",
-                   "-filter_complex \"[0:v]split[a][b];[a]palettegen=stats_mode=diff[p];[b][p]paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle\""),
-        ConfigItem("FFmpeg", "apngParam", "-vf \"setpts=PTS-STARTPTS,hqdn3d=1.5:1.5:6:6\" -plays 0"),
+                   "-filter_complex [0:v]split[a][b];[a]palettegen=stats_mode=diff[p];[b][p]paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle"),
+        ConfigItem("FFmpeg", "apngParam", "-vf setpts=PTS-STARTPTS,hqdn3d=1.5:1.5:6:6 -plays 0"),
         ConfigItem("FFmpeg", "verboseOutput", False),
 
         ConfigItem("Ugoira", "writeUgoiraInfo", False),

--- a/PixivHelper.py
+++ b/PixivHelper.py
@@ -965,7 +965,7 @@ def ugoira2gif(ugoira_file, exportname, fmt='gif', image=None):
     print_and_log('info', 'Processing ugoira to animated gif...')
     # Issue #802 use ffmpeg to convert to gif
     if len(_config.gifParam) == 0:
-        _config.gifParam = "-filter_complex \"[0:v]split[a][b];[a]palettegen=stats_mode=diff[p];[b][p]paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle\""
+        _config.gifParam = "-filter_complex [0:v]split[a][b];[a]palettegen=stats_mode=diff[p];[b][p]paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle"
     convert_ugoira(ugoira_file,
                    exportname,
                    ffmpeg=_config.ffmpeg,
@@ -979,7 +979,7 @@ def ugoira2apng(ugoira_file, exportname, image=None):
     print_and_log('info', 'Processing ugoira to apng...')
     # fix #796 convert apng using ffmpeg
     if len(_config.apngParam) == 0:
-        _config.apngParam = "-vf \"setpts=PTS-STARTPTS,hqdn3d=1.5:1.5:6:6\" -plays 0"
+        _config.apngParam = "-vf setpts=PTS-STARTPTS,hqdn3d=1.5:1.5:6:6 -plays 0"
     convert_ugoira(ugoira_file,
                    exportname,
                    ffmpeg=_config.ffmpeg,
@@ -1026,11 +1026,11 @@ def convert_ugoira(ugoira_file, exportname, ffmpeg, codec, param, extension, ima
         name = '.'.join(ugoira_file.split('.')[:-1])
         exportname = f"{os.path.basename(name)}.{extension}"
 
-    tempname = d + "/temp." + extension
+    tempname = d + os.sep + "temp." + extension
 
-    cmd = f"{ffmpeg} -y -safe 0 -i \"{d}/i.ffconcat\" -c:v {codec} {param} \"{tempname}\""
+    cmd = f"{ffmpeg} -y -safe 0 -i {d}{os.sep}i.ffconcat -c:v {codec} {param} {tempname}"
     if codec is None:
-        cmd = f"{ffmpeg} -y -safe 0 -i \"{d}/i.ffconcat\" {param} \"{tempname}\""
+        cmd = f"{ffmpeg} -y -safe 0 -i {d}{os.sep}i.ffconcat {param} {tempname}"
 
     try:
         frames = {}
@@ -1039,7 +1039,7 @@ def convert_ugoira(ugoira_file, exportname, ffmpeg, codec, param, extension, ima
         with zipfile.ZipFile(ugoira_file) as f:
             f.extractall(d)
 
-        with open(d + "/animation.json") as f:
+        with open(d + f"{os.sep}animation.json") as f:
             frames = json.load(f)['frames']
 
         for i in frames:
@@ -1049,12 +1049,12 @@ def convert_ugoira(ugoira_file, exportname, ffmpeg, codec, param, extension, ima
         # this will increase the frame count, but will fix the last frame timestamp issue.
         ffconcat += "file " + frames[-1]['file'] + '\n'
 
-        with open(d + "/i.ffconcat", "w") as f:
+        with open(d + f"{os.sep}i.ffconcat", "w") as f:
             f.write(ffconcat)
 
         check_image_encoding(d)
 
-        ffmpeg_args = shlex.split(cmd)
+        ffmpeg_args = shlex.split(cmd, posix=False)
         get_logger().info(f"[convert_ugoira()] running with cmd: {cmd}")
         p = subprocess.Popen(ffmpeg_args, stderr=subprocess.PIPE)
 

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1678,7 +1678,7 @@ def main():
 
             import shlex
             cmd = f"{__config__.ffmpeg} -encoders"
-            ffmpeg_args = shlex.split(cmd)
+            ffmpeg_args = shlex.split(cmd, posix=False)
             try:
                 p = subprocess.run(ffmpeg_args, stderr=subprocess.PIPE, stdout=subprocess.PIPE, text=True, check=True)
                 buff = p.stdout


### PR DESCRIPTION
Tested on python script for simple ffmpeg call and path to ffmpeg executable: 
- Windows 10
- MacOS Catalina 10.15.7
- Linux (Ubuntu 22.04)

Some fields of the [FFmpeg] part of the config file will need to be change in order to run the script without errors.