### PR TITLE
Fix issue with fanbox coverImageUrl (#1181)

### DIFF
--- a/PixivModelFanbox.py
+++ b/PixivModelFanbox.py
@@ -95,7 +95,7 @@ class FanboxPost(object):
         if jsPost.get("coverImageUrl"):
             coverUrl = jsPost["coverImageUrl"]
         else:
-           if jsPost.get("cover") and jsPost["cover"] is not None:
+           if jsPost.get("cover") and jsPost["cover"] is not None and jsPost["cover"]["type"] == "cover_image":
               coverUrl = jsPost["cover"]["url"]
            else:
               coverUrl = None
@@ -341,7 +341,8 @@ class FanboxPost(object):
                 js_keys = key.split(".")
                 root = embedData
                 for js_key in js_keys:
-                    if js_key == "url" and root is None:
+                    if js_key == "cover" and (root["cover"] is None or root["cover"]["type"] != "cover_image"):
+                        root = None
                         break
                     else:
                         root = root[js_key]

--- a/PixivModelFanbox.py
+++ b/PixivModelFanbox.py
@@ -341,7 +341,7 @@ class FanboxPost(object):
                 js_keys = key.split(".")
                 root = embedData
                 for js_key in js_keys:
-                    if js_key == "url" and not root.get(js_key):
+                    if js_key == "url" and root is None:
                         root = None
                     else:
                         root = root[js_key]

--- a/PixivModelFanbox.py
+++ b/PixivModelFanbox.py
@@ -342,7 +342,7 @@ class FanboxPost(object):
                 root = embedData
                 for js_key in js_keys:
                     if js_key == "url" and root is None:
-                        root = None
+                        break
                     else:
                         root = root[js_key]
                 keys.append(root)

--- a/PixivModelFanbox.py
+++ b/PixivModelFanbox.py
@@ -341,7 +341,10 @@ class FanboxPost(object):
                 js_keys = key.split(".")
                 root = embedData
                 for js_key in js_keys:
-                    root = root[js_key]
+                    if js_key == "url" and not root.get(js_key):
+                        root = None
+                    else:
+                        root = root[js_key]
                 keys.append(root)
             template = embed_cfg[current_provider]["format"]
 

--- a/PixivModelFanbox.py
+++ b/PixivModelFanbox.py
@@ -91,7 +91,14 @@ class FanboxPost(object):
     def parsePost(self, jsPost):
         self.imageTitle = jsPost["title"]
 
-        coverUrl = jsPost["coverImageUrl"]
+        # Issue 1181
+        if jsPost.get("coverImageUrl"):
+            coverUrl = jsPost["coverImageUrl"]
+        else:
+           if jsPost.get("cover") and jsPost["cover"] is not None:
+              coverUrl = jsPost["cover"]["url"]
+           else:
+              coverUrl = None
         # Issue #930
         if not self.coverImageUrl and coverUrl:
             self.coverImageUrl = _re_fanbox_cover.sub("fanbox", coverUrl)

--- a/content_provider.json
+++ b/content_provider.json
@@ -55,7 +55,7 @@
 		"fanbox.post": {
 			"type": "fanbox.post",
 			"get_link_keys": ["postInfo.excerpt"],
-			"keys": ["postInfo.title", "postInfo.coverImageUrl", "postInfo.excerpt", "postInfo.creatorId", "postInfo.id"],
+			"keys": ["postInfo.title", "postInfo.cover.url", "postInfo.excerpt", "postInfo.creatorId", "postInfo.id"],
 			"format": "<h3><a href='https://www.fanbox.cc/@{3}/posts/{4}'>{0}</a></h3>\n<p><img src='{1}'/></p>\n<p>{2}</p>\n",
 			"ignore": false
 		},

--- a/test/fanbox_urlembed.json
+++ b/test/fanbox_urlembed.json
@@ -394,7 +394,10 @@
                             "name": "くりから",
                             "iconUrl": "https://pixiv.pximg.net/c/160x160_90_a2_g5/fanbox/public/images/user/24176/icon/zB9nJnJXIzJZpKncOMcB7UqM.jpeg"
                         },
-                        "coverImageUrl": "https://pixiv.pximg.net/c/1200x630_90_a2_g5/fanbox/public/images/post/2440017/cover/9UpNbKhFOxa07nw0x0TGhOHv.jpeg",
+                        "cover": {
+                            "type": "cover_image",
+                            "url": "https://pixiv.pximg.net/c/1200x630_90_a2_g5/fanbox/public/images/post/2440017/cover/9UpNbKhFOxa07nw0x0TGhOHv.jpeg"
+                        },
                         "excerpt": "Twitterでも告知したのですがこちらでも改めまして。\n現在発売中のペンギンクラブ2021年08月号にて\n「パイズリ専門風俗パイデルン」のep02を描かせて頂きました。\nhttps://www.s2comix.com/Magazines/view/m01\n今回はおっとりとしたお姉さんに優しくちんちん挟んでもらえるお話です。\nぱふぱふ→授乳手コキ→馬乗りパイズ...",
                         "publishedDatetime": "2021-07-03T21:02:31+09:00"
                     }


### PR DESCRIPTION
This is to address issue #1181.  It looks like the post list and posts themselves use a different key for the cover image (I am assuming this is new, due to the error only showing up now) so calling ParsePost on an entry from the list (which uses a "cover" object which either has a type and url key or nothing) during the post initialization in parsePosts will break as it is expecting simply a coverImageUrl key.  The change here will handle it differently depending on whether it finds the coverImageUrl key or not.  I am unsure if any other checking needs to be done in the situation where "cover" is found instead.  The url key/value pair seems to always come with another key of "type" and value of "cover_image", so it may be necessary to also check for that before assuming there will always be a "url" whenever cover is not None, in the event that there is another cover "type" that I am unaware of.