### PR TITLE
fix: remove trim `_pxx`

### DIFF
--- a/PixivImageHandler.py
+++ b/PixivImageHandler.py
@@ -322,8 +322,6 @@ def process_image(caller,
                                                           searchTags=search_tags,
                                                           useTranslatedTag=config.useTranslatedTag,
                                                           tagTranslationLocale=config.tagTranslationLocale)
-                # trim _pXXX
-                info_filename = re.sub(r'_p?\d+$', '', info_filename)
                 info_filename = PixivHelper.sanitize_filename(info_filename + ".infoext", target_dir)
                 if config.writeImageInfo:
                     image.WriteInfo(info_filename[:-8] + ".txt")
@@ -335,8 +333,6 @@ def process_image(caller,
                                                               fileUrl=url,
                                                               appendExtension=False
                                                               )
-                    # trim _pXXX
-                    json_filename = re.sub(r'_p?\d+$', '', json_filename)
                     json_filename = PixivHelper.sanitize_filename(json_filename + ".json", target_dir)
                     image.WriteSeriesData(image.seriesNavData['seriesId'], caller.__seriesDownloaded, json_filename)
                 if config.writeImageXMP and not config.writeImageXMPPerImage:


### PR DESCRIPTION
This should fix for some pictures titled end with _xxx, e.g. https://www.pixiv.net/artworks/100345141

`リコリス・リコイル_02.txt` shouldn't be trimed to `リコリス・リコイル.txt`

However, I don't know why `info_filename = re.sub(r'_p?\d+$', '', info_filename)` code exists. I checked the commit history and found that this was added six years ago, I think it may be a historical problem