### PR TITLE
Add the unused configuration option "extensionFilter" to the app.

### DIFF
--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -212,6 +212,7 @@ class PixivConfig():
         ConfigItem("DownloadControl", "skipUnknownSize", False),
         ConfigItem("DownloadControl", "enablePostProcessing", False),
         ConfigItem("DownloadControl", "postProcessingCmd", ""),
+        ConfigItem("DownloadControl", "extensionFilter", ""),
     ]
 
     def __init__(self):

--- a/readme.md
+++ b/readme.md
@@ -612,6 +612,10 @@ Please refer run with `--help` for latest information.
 
   Skip downloading if the remote size is not known when `alwaysCheckFileSize` is set to True.
 
+- extensionFilter
+
+  Provide a | seperated list of acceptable file extensions to download. Eg. jpg|png|gif|ugoira
+
 ## [FFmpeg]
 - ffmpeg
 


### PR DESCRIPTION
This change allows users to put an extensionFilter configuration in their config.ini.

My personal use case is to only ever download images and never ugoiras with jpg|png|gif.