### PR TITLE
Add option to manually specify file extension inside file names.

### DIFF
--- a/PixivHelper.py
+++ b/PixivHelper.py
@@ -218,6 +218,7 @@ def make_filename(nameFormat: str,
     nameFormat = nameFormat.replace('%image_id%', str(imageInfo.imageId))
     nameFormat = nameFormat.replace('%works_date%', imageInfo.worksDate)
     nameFormat = nameFormat.replace('%works_date_only%', imageInfo.worksDate.split(' ')[0])
+    nameFormat = nameFormat.replace('%file_ext%', imageExtension)
 
     # Issue #1064
     if hasattr(imageInfo, "translated_work_title") and len(imageInfo.translated_work_title) > 0:

--- a/readme.md
+++ b/readme.md
@@ -769,6 +769,10 @@ filenameFormatFanboxCover, filenameFormatFanboxContent and filenameFormatFanboxI
    Current date using custom format.
    Use Python string format notation, refer: https://goo.gl/3UiMAb
    e.g. %date_fmt{%Y-%m-%d}%
+-> %file_ext%
+   The image's file extension (jpg, png, etc.), the "." is not included.
+   The correct file extension is already appended to the end of all files.
+   This is available if you want to add more, or want to add the image's file extension to info files etc.
 ```
 Available for filenameFormat and filenameMangaFormat:
 ```


### PR DESCRIPTION
Digikam recently changed the behaviour of XMP sidecar files and now they need to match the full file-name of the associated image, ie. what used to be:
> image.jpg
> image.xmp

is now:
> image.jpg
> image.jpg.xmp

This PR adds the option to use %file_ext% in the file naming process so I can change my filename config to say "image.%file_ext%".

Now I have to go rename 140,000 sidecar files thanks Digikam...