### PR TITLE
Fixes to option 15 novel series downloader

### DIFF
--- a/PixivNovel.py
+++ b/PixivNovel.py
@@ -162,5 +162,5 @@ class NovelSeries:
                                  errorCode=PixivException.UNKNOWN_IMAGE_ERROR,
                                  htmlPage=page_info)
 
-        self.series_list.extend(js["body"]["seriesContents"])
+        self.series_list.extend(js["body"]["page"]["seriesContents"])
         self.series_list_str[current_page] = page_info

--- a/PixivNovelHandler.py
+++ b/PixivNovelHandler.py
@@ -101,13 +101,13 @@ def process_novel_series(caller,
     while (flag):
         PixivHelper.print_and_log(None, f"Getting page = {page}")
         novel_series = caller.__br__.getNovelSeriesContent(novel_series, current_page=page)
-        page = page + 1
         if end_page > 0 and page > end_page:
             PixivHelper.print_and_log(None, f"Page limit reached = {end_page}.")
             flag = False
         if (page * PixivNovel.MAX_LIMIT) >= novel_series.total:
             PixivHelper.print_and_log(None, "No more novel.")
             flag = False
+        page = page + 1
 
     for novel in novel_series.series_list:
         process_novel(caller,


### PR DESCRIPTION
Partially related to #1234 when trying to download novel series got error of not finding js key "seriesContents" that was placed more deep in page. And also fixed when for example total count of novels was 34 but actual number of downloaded was 30