### PR TITLE
Fixed Inappropriate Logical Expression

### DIFF
--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -693,7 +693,7 @@ class PixivBrowser(mechanize.Browser):
                     self._put_to_cache(url, info)
             else:
                 PixivHelper.print_and_log('info', f'Using OAuth to retrieve member info for: {member_id}')
-                if self._username is None or self._password is None or len(self._username) < 0 or len(self._password) < 0:
+                if not self._username or not self._password:
                     raise PixivException("Empty Username or Password, remove cookie value and relogin, or add username/password to config.ini.")
 
                 url = f'https://app-api.pixiv.net/v1/user/detail?user_id={member_id}'


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [PixivBrowserFactory.py](https://github.com/Nandaka/PixivUtil2/tree/master/PixivBrowserFactory.py#L696), the comparison of Collection length creates a logical short circuit. iCR suggested that the Collection length comparison should be done without creating a logical short circuit.

As a result, I've modified the conditions to a simpler one. Just checking them with a `not` before achieves the same goal.

#### Example
Running the following code gives the output-
```python
# case 1
username = ""
password = ""
if not username or not password:
	print("Inside")

# case 2
username = None
password = None
if not username or not password:
	print("Inside")
```
```
Inside
Inside
```


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
