### PR TITLE
Change useragent to something that doesn't get blocked

### DIFF
--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -57,8 +57,7 @@ class PixivConfig():
     __items = [
         ConfigItem("Network", "useProxy", False),
         ConfigItem("Network", "proxyAddress", ""),
-        ConfigItem("Network", "useragent",
-                   "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0"),
+        ConfigItem("Network", "useragent", "Mozilla/5.0"),
         ConfigItem("Network", "useRobots", True),
         ConfigItem("Network", "timeout", 60),
         ConfigItem("Network", "retry", 3),

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1729,6 +1729,7 @@ def main():
             print(Fore.RED + Style.BRIGHT + "No username and/or password found in config.ini" + Style.RESET_ALL)
             print(Fore.YELLOW + Style.BRIGHT + "See " + Style.RESET_ALL + Fore.CYAN + Style.BRIGHT +
                   "https://github.com/Nandaka/PixivUtil2?tab=readme-ov-file#authentication" + Style.RESET_ALL)
+
         if np_is_valid and options.number_of_pages != 0:  # Yavos: overwrite config-data
             PixivHelper.print_and_log("info", f'Limit up to: {options.number_of_pages} page(s). (set via commandline)')
         elif __config__.numberOfPage != 0:

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1724,15 +1724,7 @@ def main():
               Fore.CYAN + Style.BRIGHT + "https://github.com/Nandaka/PixivUtil2?tab=readme-ov-file#a-usage" + Style.RESET_ALL)
 
         username = __config__.username
-        # if username == '':
-        #     username = input('Username ? ').rstrip("\r")
-        # else:
-        #     msg = f'Using Username: {username}'
-        #     PixivHelper.print_and_log('info', msg)
-
         password = __config__.password
-        # if password == '':
-        #     password = getpass.getpass('Password ? ')
 
         if np_is_valid and options.number_of_pages != 0:  # Yavos: overwrite config-data
             PixivHelper.print_and_log("info", f'Limit up to: {options.number_of_pages} page(s). (set via commandline)')

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1725,7 +1725,10 @@ def main():
 
         username = __config__.username
         password = __config__.password
-
+        if not username or not password:
+            print(Fore.RED + Style.BRIGHT + "No username and/or password found in config.ini" + Style.RESET_ALL)
+            print(Fore.YELLOW + Style.BRIGHT + "See " + Style.RESET_ALL + Fore.CYAN + Style.BRIGHT +
+                  "https://github.com/Nandaka/PixivUtil2?tab=readme-ov-file#authentication" + Style.RESET_ALL)
         if np_is_valid and options.number_of_pages != 0:  # Yavos: overwrite config-data
             PixivHelper.print_and_log("info", f'Limit up to: {options.number_of_pages} page(s). (set via commandline)')
         elif __config__.numberOfPage != 0:


### PR DESCRIPTION
Looks like https://github.com/Nandaka/PixivUtil2/issues/1239 is still the case, with pixiv now blocking the current user agent, too. Switching it to the recommended value from 1239, however, works.