### PR TITLE
Gracefully handle FANBOX Cloudflare check failures.

### DIFF
--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -214,10 +214,8 @@ class PixivBrowser(mechanize.Browser):
                         print(f"Redirect to {res.headers['location']}")
                 else:
                     # Issue #1342
-                    errorCode = error.getcode()
-                    errorMessage = error.get_data()
-                    if "challenge_basic_security_FANBOX" in str(errorMessage) and errorCode == 403:
-                        return errorMessage
+                    if "challenge_basic_security_FANBOX" in str(error.get_data()) and error.getcode() == 403:
+                        return error
                 raise
             except BaseException:
                 exc_value = sys.exc_info()[1]
@@ -416,7 +414,7 @@ class PixivBrowser(mechanize.Browser):
             try:
                 res = self.open_with_retry(req)
                 parsed = BeautifulSoup(res, features="html5lib")
-                PixivHelper.get_logger().info('Logging in with cookit to Fanbox, return url: %s', res.geturl())
+                PixivHelper.get_logger().info('Logging in with cookie to Fanbox, return url: %s', res.geturl())
                 res.close()
             except BaseException:
                 PixivHelper.get_logger().error('Error at fanboxLoginUsingCookie(): %s', sys.exc_info())

--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -427,8 +427,11 @@ class PixivBrowser(mechanize.Browser):
                 self._is_logged_in_to_FANBOX = True
             # Issue #1342
             elif "challenge_basic_security_FANBOX" in str(parsed.decode('utf-8')):
+                fanboxErrorPage = parsed.decode('utf-8')
+                parsed.decompose()
+                del parsed
                 raise PixivException("Failed FANBOX Cloudflare CAPTCHA challenge, please check your cookie and user-agent settings.", 
-                                             errorCode=PixivException.CANNOT_LOGIN, htmlPage=parsed.decode('utf-8'))
+                                             errorCode=PixivException.CANNOT_LOGIN, htmlPage=fanboxErrorPage)
             parsed.decompose()
             del parsed
 

--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -206,7 +206,7 @@ class PixivBrowser(mechanize.Browser):
             try:
                 res = self.open(url, data, timeout)
                 return res
-            except urllib.error.HTTPError as error:
+            except urllib.error.HTTPError as fanboxError:
                 if res is not None:
                     print(f"Error Code: {res.code}")
                     print(f"Response Headers: {res.headers}")
@@ -214,8 +214,8 @@ class PixivBrowser(mechanize.Browser):
                         print(f"Redirect to {res.headers['location']}")
                 else:
                     # Issue #1342
-                    if "challenge_basic_security_FANBOX" in str(error.get_data()) and error.getcode() == 403:
-                        return error
+                    if "challenge_basic_security_FANBOX" in str(fanboxError.get_data()) and fanboxError.getcode() == 403:
+                        return fanboxError
                 raise
             except BaseException:
                 exc_value = sys.exc_info()[1]

--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -427,8 +427,6 @@ class PixivBrowser(mechanize.Browser):
                 self._is_logged_in_to_FANBOX = True
             # Issue #1342
             elif "challenge_basic_security_FANBOX" in str(parsed.decode('utf-8')):
-                result = False
-                self._is_logged_in_to_FANBOX = False
                 raise PixivException("Failed FANBOX Cloudflare CAPTCHA challenge, please check your cookie and user-agent settings.", 
                                              errorCode=PixivException.CANNOT_LOGIN, htmlPage=parsed.decode('utf-8'))
             parsed.decompose()


### PR DESCRIPTION
The `AttributeError: 'str' object has no attribute 'decode'` was being thrown due to an unhandled condition where `open_with_retry` would initialize `res` to `None` yet except an `urllib.error.HTTPError` error. To handle this, we check the status code (`403`) and if a specific string (`challenge_basic_security_FANBOX`) is found in the returned html. If both conditions are true, we know we have failed the Fanbox Captcha verification, dump the html, then exit.