### PR TITLE
Add support for encoding AVIF

### DIFF
--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -188,6 +188,8 @@ class PixivConfig():
         ConfigItem("FFmpeg", "gifParam",
                    "-filter_complex [0:v]split[a][b];[a]palettegen=stats_mode=diff[p];[b][p]paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle -vsync 0"),
         ConfigItem("FFmpeg", "apngParam", "-plays 0 -vsync 0"),
+        ConfigItem("FFmpeg", "avifCodec", "libaom-av1"),
+        ConfigItem("FFmpeg", "avifParam", "-cpu-used 4 -crf 0 -row-mt 1 -tile-columns 2 -tile-rows 2 -vsync 0"),
         ConfigItem("FFmpeg", "verboseOutput", False),
 
         ConfigItem("Ugoira", "writeUgoiraInfo", False),
@@ -197,6 +199,7 @@ class PixivConfig():
         ConfigItem("Ugoira", "createWebp", False),
         ConfigItem("Ugoira", "createGif", False),
         ConfigItem("Ugoira", "createApng", False),
+        ConfigItem("Ugoira", "createAvif", False),
         ConfigItem("Ugoira", "deleteUgoira", False),
         ConfigItem("Ugoira", "deleteZipFile", False),
 

--- a/PixivDownloadHandler.py
+++ b/PixivDownloadHandler.py
@@ -418,6 +418,13 @@ def handle_ugoira(image, zip_filename, config, notifier):
                                     apng_filename,
                                     image=image)
 
+    if config.createAvif:
+        avif_filename = ugo_name[:-7] + ".avif"
+        if not os.path.exists(avif_filename):
+            PixivHelper.ugoira2avif(ugo_name,
+                                    avif_filename,
+                                    image=image)
+
     if config.createWebm:
         webm_filename = ugo_name[:-7] + "." + config.ffmpegExt
         if not os.path.exists(webm_filename):

--- a/PixivHelper.py
+++ b/PixivHelper.py
@@ -1020,6 +1020,19 @@ def ugoira2apng(ugoira_file, exportname, image=None):
                    image=image)
 
 
+def ugoira2avif(ugoira_file, exportname, image=None):
+    print_and_log('info', 'Processing ugoira to avif...')
+    if len(_config.avifParam) == 0:
+        _config.avifParam = "-cpu-used 4 -crf 0 -row-mt 1 -tile-columns 2 -tile-rows 2 -vsync 0"
+    convert_ugoira(ugoira_file,
+                   exportname,
+                   ffmpeg=_config.ffmpeg,
+                   codec=_config.avifCodec,
+                   param=_config.avifParam,
+                   extension="avif",
+                   image=image)
+
+
 def ugoira2webp(ugoira_file, exportname, image=None):
     print_and_log('info', 'Processing ugoira to webp...')
     if len(_config.webpParam) == 0:

--- a/PixivImageHandler.py
+++ b/PixivImageHandler.py
@@ -325,6 +325,9 @@ def process_image(caller,
                         if config.createApng:
                             info_filename = get_info_filename("apng")
                             image.WriteXMP(info_filename, config.useTranslatedTag, config.tagTranslationLocale)
+                        if config.createAvif:
+                            info_filename = get_info_filename("avif")
+                            image.WriteXMP(info_filename, config.useTranslatedTag, config.tagTranslationLocale)
                         if config.createWebm:
                             info_filename = get_info_filename("webm")
                             image.WriteXMP(info_filename, config.useTranslatedTag, config.tagTranslationLocale)
@@ -531,6 +534,7 @@ def process_ugoira_local(caller, config):
                             if ((("gif" in file_ext) and (config.createGif))
                                or (("mkv" in file_ext) and (config.createMkv))
                                or (("png" in file_ext) and (config.createApng))
+                               or (("avif" in file_ext) and (config.createAvif))
                                or (("webm" in file_ext) and (config.createWebm))
                                or (("webp" in file_ext) and (config.createWebp))
                                or (("ugoira" in file_ext) and (config.createUgoira))
@@ -591,6 +595,7 @@ def process_ugoira_local(caller, config):
                                  or (not config.deleteZipFile and "zip" in file_ext)
                                  or (config.createGif and "gif" in file_ext)
                                  or (config.createApng and "png" in file_ext)
+                                 or (config.createAvif and "avif" in file_ext)
                                  or (config.createWebm and "webm" in file_ext)
                                  or (config.createWebp and "webp" in file_ext)):
                                 split_name = file_name.rsplit(".", 1)

--- a/readme.md
+++ b/readme.md
@@ -662,6 +662,12 @@ Please refer run with `--help` for latest information.
 - mkvparam
 
   Parameter to be used to encode mkv, default: ` `.
+- avifcodec
+
+  Codec to be used for encoding avif, default is using `libaom-av1`.
+- avifparam
+
+  Parameter to be used to encode avif, default: `-cpu-used 4 -crf 0 -row-mt 1 -tile-columns 2 -tile-rows 2 -vsync 0`.
 - webpcodec
 
   Codec to be used for encoding webm, default is using `libwebp`.
@@ -696,6 +702,10 @@ Please refer run with `--help` for latest information.
 - createapng
 
   Set to True to convert ugoira file to animated png. The default encoding settings is lossless encoding but very large file size.
+  Required `createUgoira = True` and ffmpeg executeable.
+- createavif
+
+  Set to True to convert ugoira file to avif. The default encoding settings is lossless encoding with comparable filesizes to webp.
   Required `createUgoira = True` and ffmpeg executeable.
 - deleteugoira
 


### PR DESCRIPTION
This commit adds support for AVIF encoded Ugoiras.
The default settings are `-cpu-used 4 -crf 0 -row-mt 1 -tile-columns 2 -tile-rows 2 -vsync 0`

I chose lossless encoding because AVIF offers good filesize even with lossless, often being not much larger or even smaller than lossy WebP, while retaining the full image quality.