### PR TITLE
Additional SSL verification skip

### DIFF
--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -174,6 +174,7 @@ class PixivBrowser(mechanize.Browser):
             else:
                 # Handle target environment that doesn't support HTTPS verification
                 ssl._create_default_https_context = _create_unverified_https_context
+                self.set_ca_data(context=_create_unverified_https_context())
 
     def _configureCookie(self, cookie_jar):
         if cookie_jar is not None:


### PR DESCRIPTION
Even with enableSSLVerification set to false, I was getting CERTIFICATE_VERIFY_FAILED errors in my environment (fiddler proxy on Windows capturing traffic from python on WSL1)
Found this in https://webscraping.ai/faq/mechanize/can-mechanize-bypass-ssl-certificate-verification