### PR TITLE
Fix downloadDelay not working for fanbox downloads

### DIFF
--- a/PixivFanboxHandler.py
+++ b/PixivFanboxHandler.py
@@ -70,7 +70,7 @@ def process_fanbox_artist_by_id(caller, config, artist_id, end_page, title_prefi
             else:
                 PixivHelper.print_and_log("info", f"Unsupported post type: {post.imageId} => {post.type}")
             image_count += 1
-            PixivHelper.wait(config)
+            PixivHelper.wait(config=config)
 
         if not artist.hasNextPage:
             PixivHelper.print_and_log("info", "No more post for {0}".format(artist))


### PR DESCRIPTION
Bug fix

`PixivHelper.wait` accepts two keyword arguments `result` and `config`. Because only one (positional) argument was passed to `PixivHelper.wait` for fanbox downloads, `config` was passed as the `result` argument, causing the delay to not be applied even when `downloadDelay` was set in config.

I wasn't sure what value `result` should be, so I changed the function call so that the `config` variable is passed as a keyword argument, while implicitly setting the `result` argument to the default value of `None`. Hope this is ok