### PR TITLE
Option to add Pixiv illust captions to db

### DIFF
--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -155,6 +155,7 @@ class PixivConfig():
         ConfigItem("Pixiv", "r18Type", 0),  # Issue #439
         ConfigItem("Pixiv", "dateFormat", ""),
         ConfigItem("Pixiv", "autoAddMember", False),
+        ConfigItem("Pixiv", "autoAddCaption", False),
         ConfigItem("Pixiv", "aiDisplayFewer", False),
 
         ConfigItem("FANBOX", "filenameFormatFanboxCover",

--- a/PixivDBManager.py
+++ b/PixivDBManager.py
@@ -88,6 +88,12 @@ class PixivDBManager(object):
                     '''ALTER TABLE pixiv_master_image ADD COLUMN is_manga TEXT''')
             except BaseException:
                 pass
+            # add column caption
+            try:
+                c.execute(
+                    '''ALTER TABLE pixiv_master_image ADD COLUMN caption TEXT''')
+            except BaseException:
+                pass
 
             c.execute('''CREATE TABLE IF NOT EXISTS pixiv_manga_image (
                             image_id INTEGER,
@@ -742,13 +748,13 @@ class PixivDBManager(object):
 ##########################################
 # V. CRUD Image Table                    #
 ##########################################
-    def insertImage(self, member_id, image_id, isManga=""):
+    def insertImage(self, member_id, image_id, isManga="", caption=""):
         try:
             c = self.conn.cursor()
             member_id = int(member_id)
             image_id = int(image_id)
-            c.execute('''INSERT OR IGNORE INTO pixiv_master_image VALUES(?, ?, 'N/A' ,'N/A' , datetime('now'), datetime('now'), ? )''',
-                      (image_id, member_id, isManga))
+            c.execute('''INSERT OR IGNORE INTO pixiv_master_image VALUES(?, ?, 'N/A' ,'N/A' , datetime('now'), datetime('now'), ?, ? )''',
+                      (image_id, member_id, isManga, caption))
             self.conn.commit()
         except BaseException:
             print('Error at insertImage():', str(sys.exc_info()))
@@ -836,12 +842,12 @@ class PixivDBManager(object):
         finally:
             c.close()
 
-    def updateImage(self, imageId, title, filename, isManga=""):
+    def updateImage(self, imageId, title, filename, isManga=None, caption=None):
         try:
             c = self.conn.cursor()
             c.execute('''UPDATE pixiv_master_image
-                      SET title = ?, save_name = ?, last_update_date = datetime('now'), is_manga = ?
-                      WHERE image_id = ?''', (title, filename, isManga, imageId))
+                      SET title = ?, save_name = ?, last_update_date = datetime('now'), is_manga = COALESCE(?, is_manga), caption= COALESCE(?, caption)
+                      WHERE image_id = ?''', (title, filename, isManga, caption, imageId))
             self.conn.commit()
         except BaseException:
             print('Error at updateImage():', str(sys.exc_info()))

--- a/PixivImageHandler.py
+++ b/PixivImageHandler.py
@@ -415,8 +415,9 @@ def process_image(caller,
         if result in (PixivConstant.PIXIVUTIL_OK,
                       PixivConstant.PIXIVUTIL_SKIP_DUPLICATE,
                       PixivConstant.PIXIVUTIL_SKIP_LOCAL_LARGER):
+            caption = image.imageCaption if config.autoAddCaption else ""
             try:
-                db.insertImage(image.artist.artistId, image.imageId, image.imageMode)
+                db.insertImage(image.artist.artistId, image.imageId, image.imageMode, caption=caption)
             except BaseException:
                 PixivHelper.print_and_log('error', f'Failed to insert image id:{image.imageId} to DB')
 

--- a/readme.md
+++ b/readme.md
@@ -360,6 +360,10 @@ Please refer run with `--help` for latest information.
 
   Automatically save member id to db for all download.
 
+- autoAddCaption
+
+  Automatically save captions to db for all download.
+
 - aiDisplayFewer
 
   if true, filter out AI-generated images from downloading.


### PR DESCRIPTION
Implements the opt-in option to add image captions for pixiv artworks to the database. This will add a "caption" column in `pixiv_master_image`.