### PR TITLE
Option to add Pixiv tag/caption data to db, auto add member data

### DIFF
--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -156,6 +156,7 @@ class PixivConfig():
         ConfigItem("Pixiv", "dateFormat", ""),
         ConfigItem("Pixiv", "autoAddMember", False),
         ConfigItem("Pixiv", "autoAddTag", False),
+        ConfigItem("Pixiv", "autoAddCaption", False),
         ConfigItem("Pixiv", "aiDisplayFewer", False),
 
         ConfigItem("FANBOX", "filenameFormatFanboxCover",

--- a/PixivDBManager.py
+++ b/PixivDBManager.py
@@ -88,6 +88,13 @@ class PixivDBManager(object):
                     '''ALTER TABLE pixiv_master_image ADD COLUMN is_manga TEXT''')
             except BaseException:
                 pass
+            # add column caption
+            try:
+                c.execute(
+                    '''ALTER TABLE pixiv_master_image ADD COLUMN caption TEXT''')
+            except BaseException:
+                pass
+                
 
             c.execute('''CREATE TABLE IF NOT EXISTS pixiv_manga_image (
                             image_id INTEGER,
@@ -866,13 +873,13 @@ class PixivDBManager(object):
         finally:
             c.close()
 
-    def insertImage(self, member_id, image_id, isManga=""):
+    def insertImage(self, member_id, image_id, isManga="", caption=""):
         try:
             c = self.conn.cursor()
             member_id = int(member_id)
             image_id = int(image_id)
-            c.execute('''INSERT OR IGNORE INTO pixiv_master_image VALUES(?, ?, 'N/A' ,'N/A' , datetime('now'), datetime('now'), ? )''',
-                      (image_id, member_id, isManga))
+            c.execute('''INSERT OR IGNORE INTO pixiv_master_image VALUES(?, ?, 'N/A' ,'N/A' , datetime('now'), datetime('now'), ?, ? )''',
+                      (image_id, member_id, isManga, caption))
             self.conn.commit()
         except BaseException:
             print('Error at insertImage():', str(sys.exc_info()))
@@ -960,12 +967,12 @@ class PixivDBManager(object):
         finally:
             c.close()
 
-    def updateImage(self, imageId, title, filename, isManga=""):
+    def updateImage(self, imageId, title, filename, isManga=None, caption=None):
         try:
             c = self.conn.cursor()
             c.execute('''UPDATE pixiv_master_image
-                      SET title = ?, save_name = ?, last_update_date = datetime('now'), is_manga = ?
-                      WHERE image_id = ?''', (title, filename, isManga, imageId))
+                      SET title = ?, save_name = ?, last_update_date = datetime('now'), is_manga = COALESCE(?, is_manga), caption = COALESCE(?, caption)
+                      WHERE image_id = ?''', (title, filename, isManga, caption, imageId))
             self.conn.commit()
         except BaseException:
             print('Error at updateImage():', str(sys.exc_info()))

--- a/PixivImageHandler.py
+++ b/PixivImageHandler.py
@@ -415,8 +415,9 @@ def process_image(caller,
         if result in (PixivConstant.PIXIVUTIL_OK,
                       PixivConstant.PIXIVUTIL_SKIP_DUPLICATE,
                       PixivConstant.PIXIVUTIL_SKIP_LOCAL_LARGER):
+            caption = image.imageCaption if config.autoAddCaption else ""
             try:
-                db.insertImage(image.artist.artistId, image.imageId, image.imageMode)
+                db.insertImage(image.artist.artistId, image.imageId, image.imageMode, caption=caption)
             except BaseException:
                 PixivHelper.print_and_log('error', f'Failed to insert image id:{image.imageId} to DB')
 

--- a/PixivImageHandler.py
+++ b/PixivImageHandler.py
@@ -441,6 +441,15 @@ def process_image(caller,
                                 for locale in tag_data.translation_data:
                                     db.insertTagTranslation(tag_id, locale, tag_data.translation_data[locale])
 
+            # Save member data if enabled
+            if config.autoAddMember:
+                member_id = image.artist.artistId
+                member_token = image.artist.artistToken
+                member_name = image.artist.artistName
+                if member_id and member_token and member_name:
+                    db.insertNewMember(int(member_id), member_token=member_token)
+                    db.updateMemberName(member_id, member_name, member_token)
+
             # map back to PIXIVUTIL_OK (because of ugoira file check)
             result = 0
 

--- a/readme.md
+++ b/readme.md
@@ -364,6 +364,10 @@ Please refer run with `--help` for latest information.
 
   Automatically add image tags for db for all downloads.
 
+- autoAddCaption
+
+  Automatically save captions for db for all downloads.
+
 - aiDisplayFewer
 
   if true, filter out AI-generated images from downloading.


### PR DESCRIPTION
A collection of commits intended to improve metadata preservation from Pixiv for future metadata extraction and migration to manga readers/galleries.

1. Implements the (opt-in) option to add tag data (`pixiv_master_tag`), image/tag associations (`pixiv_image_to_tag`), and tag translations (`pixiv_tag_translation`).
2. Implements the (opt-in) option to add caption data as a column to `pixiv_master_image`.
3. If `autoAddMember` is set to True: save member data automatically when downloading an image.

Example `pixiv_image_to_tag`:

![Screenshot 2024-10-31 at 10 42 58 PM](https://github.com/user-attachments/assets/f6ce44f7-e99b-4594-8bde-80239fc36e64)

Example `pixiv_master_tag`:

![Screenshot 2024-10-31 at 10 43 33 PM](https://github.com/user-attachments/assets/c002fc3f-cf6a-42f6-b6ca-9de941d05b92)

Example `pixiv_tag_translation`:

![Screenshot 2024-10-31 at 10 43 57 PM](https://github.com/user-attachments/assets/2911d375-c64a-4842-9b88-6b988d09d6ba)

