### PR TITLE
Fix unnecessary decode() calls on BeautifulSoup objects (#1403)

### DIFF
--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -351,7 +351,7 @@ class PixivBrowser(mechanize.Browser):
             self._loadCookie(login_cookie, "pixiv.net")
             res = self.open_with_retry('https://www.pixiv.net')  # + self._locale)
             parsed = BeautifulSoup(res, features="html5lib")
-            parsed_str = str(parsed.decode('utf-8'))
+            parsed_str = str(parsed)
             PixivHelper.print_and_log("info", f'Logging in, return url: {res.geturl()}')
             res.close()
             parsed.decompose()
@@ -421,11 +421,11 @@ class PixivBrowser(mechanize.Browser):
                 PixivHelper.get_logger().error('Error at fanboxLoginUsingCookie(): %s', sys.exc_info())
                 self.cookiejar.clear("fanbox.cc")
 
-            if '"user":{"isLoggedIn":true' in str(parsed.decode('utf-8')):
+            if '"user":{"isLoggedIn":true' in str(parsed):
                 result = True
                 self._is_logged_in_to_FANBOX = True
             # Issue #1342
-            elif "challenge_basic_security_FANBOX" in str(parsed.decode('utf-8')):
+            elif "challenge_basic_security_FANBOX" in str(parsed):
                 fanboxErrorPage = parsed.decode('utf-8')
                 parsed.decompose()
                 del parsed
@@ -478,7 +478,7 @@ class PixivBrowser(mechanize.Browser):
             return False
 
         result = False
-        if '"user":{"isLoggedIn":true' in str(parsed.decode('utf-8')):
+        if '"user":{"isLoggedIn":true' in str(parsed):
             result = True
             self._is_logged_in_to_FANBOX = True
         parsed.decompose()


### PR DESCRIPTION
This PR fixes the error reported in Issue #1403 by removing unnecessary `.decode('utf-8')` calls when converting BeautifulSoup objects to strings. Specifically, all occurrences of:

```py
str(parsed.decode('utf-8'))
```

have been replaced with:

```py
str(parsed)
```

in the following functions:
- `loginUsingCookie()`
- `fanboxLoginUsingCookie()` (including Cloudflare challenge handling)
- `processLoginResult()`

This eliminates the `TypeError: can't multiply sequence by non-int of type 'str'` without requiring a downgrade of `beautifulsoup4`. 