### PR TITLE
Fix incomplete downloads not recognized as such

### DIFF
--- a/PixivHelper.py
+++ b/PixivHelper.py
@@ -811,10 +811,15 @@ def download_image(url, filename, res, file_size, overwrite):
                 print_and_log(None, f' Completed in {Fore.CYAN}{total_time}{Style.RESET_ALL}s ({Fore.RED}{speed_in_str(file_size, total_time)}{Style.RESET_ALL})')
                 break
 
-            elif curr == prev:  # no file size info
+            # no file size info
+            elif file_size < 0 and curr == prev:
                 total_time = (datetime.now() - start_time).total_seconds()
                 print_and_log(None, f' Completed in {Fore.CYAN}{total_time}{Style.RESET_ALL}s ({Fore.RED}{speed_in_str(curr, total_time)}{Style.RESET_ALL})')
                 break
+
+            # incomplete download
+            elif file_size >= 0 and curr == prev:
+                raise PixivException(f"Download incomplete for: {url}", errorCode=PixivException.DOWNLOAD_FAILED_OTHER)
 
             prev = curr
     except OSError as ex:


### PR DESCRIPTION
PixivUtil2 deletes partially downloaded files, but doesn't try to download them again. On top of that it assumes these images were downloaded completely, marking them as such in the database (issue #1389).

The problem was that in ``PixivHelper.download_image``, when downloading file in parts, if Pixiv didn't send all requested parts (and therefore ``curr == prev``), PixivUtil2 would assume the download has finished, but the file size was not known: 

```python
            # check if downloaded file is complete
            if file_size > 0 and curr == file_size:
                total_time = (datetime.now() - start_time).total_seconds()
                print_and_log(None, f' Completed in {Fore.CYAN}{total_time}{Style.RESET_ALL}s ({Fore.RED}{speed_in_str(file_size, total_time)}{Style.RESET_ALL})')
                break

           elif curr == prev:  # no file size info
                total_time = (datetime.now() - start_time).total_seconds()
                print_and_log(None, f' Completed in {Fore.CYAN}{total_time}{Style.RESET_ALL}s ({Fore.RED}{speed_in_str(curr, total_time)}{Style.RESET_ALL})')
                break
```

In that case, ``file_size`` variable has to be checked. When file size is not known, the variable ``file_size`` is set to ``-1``. There is a third case, when file size is provided, but no further parts are provided. The code had to be updated:

```python
            # check if downloaded file is complete
            if file_size > 0 and curr == file_size:
                total_time = (datetime.now() - start_time).total_seconds()
                print_and_log(None, f' Completed in {Fore.CYAN}{total_time}{Style.RESET_ALL}s ({Fore.RED}{speed_in_str(file_size, total_time)}{Style.RESET_ALL})')
                break

            # no file size info
            elif file_size < 0 and curr == prev:
                total_time = (datetime.now() - start_time).total_seconds()
                print_and_log(None, f' Completed in {Fore.CYAN}{total_time}{Style.RESET_ALL}s ({Fore.RED}{speed_in_str(curr, total_time)}{Style.RESET_ALL})')
                break

            # incomplete download
            elif file_size >= 0 and curr == prev:
                raise PixivException(f"Download incomplete for: {url}", errorCode=PixivException.DOWNLOAD_FAILED_OTHER)
```

Even though in the ``finally`` block there was a condition that would check is the file size is invalid, it would not fail the download. By raising exception in the loop, PixivUtil2 acknowledges the error, waits couple of seconds, and retries just like in case of any other error.

# Possible issues

I'm not sure if using ``PixivError`` in that case is correct, but it seems fine. In the block that handles the exception, the same exception and error code is set.

This change makes PixivUtil2 exit with non-zero code. This may break some scripts that expect the program to exit with no errors. Also, every time the download fails, the stack trace is printed, which might confuse the user.

Another thing is that when the file size is not known, there is no way to check whether the download is complete or not. Even though that sounds bad, Pixiv doesn't seem to send partial data when the file size is not known (or at least I didn't notice having partially downloaded images).