### PR TITLE
Fix handling of zip files in Fanbox posts when local file exists and remote size check fails

### DIFF
--- a/PixivDownloadHandler.py
+++ b/PixivDownloadHandler.py
@@ -388,6 +388,9 @@ def get_remote_filesize(url, referer, config, notifier=None):
 
 
 def handle_ugoira(image, zip_filename, config, notifier):
+    if not hasattr(image, 'create_ugoira'): # for fanbox zips that can't resolve remote file size
+        return
+
     if notifier is None:
         notifier = PixivHelper.dummy_notifier
 


### PR DESCRIPTION
## Problem

The current implementation incorrectly processes zip files from Fanbox posts. When a zip file already exists locally and fails the remote file size check, PixivUtil calls `handle_ugoira` on the zip file. Since Fanbox post objects don't have a `create_ugoira` method, this causes download failures for the entire creator.

Example error from logs:

```log
Checking local filename... 	Cannot resolve remote file size! Skipping the download. ==> /REDACTED/REDACTED_p74_REDACTED.zip. 
Creating ugoira archive => /REDACTED/REDACTED_p74_REDACTED.ugoira 
Error at download_image(): (<class 'AttributeError'>, AttributeError("'FanboxPost' object has no attribute 'create_ugoira'"), <traceback object at 0x7fa07c5b1480>) at https://downloads.fanbox.cc/images/post/REDACTED/REDACTED.png (9000) 

Retrying [1]... 
1 of 5s. 
2 of 5s. 
3 of 5s. 
4 of 5s. 
5 of 5s.  
```

For further reference, I already have `alwaysCheckFileSize = False` in config.ini, but PixivUtil still tries to download the images. This could be caused by the author re-uploading images.

The log below looks weird, for the p0 with hash FOO1 it skips download correctly, but posts after that shows fail to check remote file size for hash foo2 (which is the cover image), and "Saved to" filename is different that what I have in local.

```log
#4
Post  = REDACTED
Title = REDACTED
Type  = image
Created Date  = REDACTED
Is Restricted = False
Downloading cover from https://pixiv.pximg.net/fanbox/public/images/post/REDACTED/cover/FOO2.jpeg
Saved to /REDACTED/REDACTED_FOO2.jpeg

Checking local filename... 
Local file exists: /REDACTED/REDACTED_FOO2.jpeg 
Image Count = 13
Downloading image 0 from https://downloads.fanbox.cc/images/post/REDACTED/FOO1.png
Saved to /REDACTED/REDACTED_p0_FOO1.png

Checking local filename... 	Cannot resolve remote file size! Skipping the download. ==> /REDACTED/REDACTED_FOO2.jpeg. 
Downloading image 1 from https://downloads.fanbox.cc/images/post/REDACTED/FOO3.png
Saved to /REDACTED/REDACTED_p1_FOO3.png

Checking local filename... 	Cannot resolve remote file size! Skipping the download. ==> /REDACTED/REDACTED_FOO2.jpeg. 
Downloading image 2 from https://downloads.fanbox.cc/images/post/REDACTED/FOO4.png
Saved to /REDACTED/REDACTED_p2_FOO4.png

Checking local filename... 	Cannot resolve remote file size! Skipping the download. ==> /REDACTED/REDACTED_FOO2.jpeg. 
Downloading image 3 from https://downloads.fanbox.cc/images/post/REDACTED/FOO5.png
Saved to /REDACTED/REDACTED_p3_FOO5.png
```

## Solution

Added a check at the beginning of `handle_ugoira` to verify that the image object has a `create_ugoira` function. This simple change prevents the function from attempting to process Fanbox posts while maintaining the existing logic for other types.