### PR TITLE
Restart automatically on ConnectionResetError in download_image

### DIFF
--- a/PixivHelper.py
+++ b/PixivHelper.py
@@ -822,6 +822,11 @@ def download_image(url, filename, res, file_size, overwrite):
                 raise PixivException(f"Download incomplete for: {url}", errorCode=PixivException.DOWNLOAD_FAILED_OTHER)
 
             prev = curr
+
+    except ConnectionResetError as ex:
+        print_and_log('error', f"ConnectionResetError at download_image(): Cannot save {url} to {filename}: {sys.exc_info()}", exception=ex)
+        raise
+
     except OSError as ex:
         print_and_log('error', f"Error at download_image(): Cannot save {url} to {filename}: {sys.exc_info()}", exception=ex)
         input("Press enter to continue or Ctrl+C to abort.")  # Issue #1187


### PR DESCRIPTION
Fixes #1415. Because ``ConnectionResetError`` is handled as OSError, the confirmation from the user is required. After this PR no confirmation is required.

In some sense this fixes Windows-only version of #1389 issue. Both are caused by ``res.read(BUFFER_SIZE)`` not being able to read further data due to remote host forcibly closing connection. On Linux there is no exception raised, that used to cause incomplete downloads. On Windows, there is ``ConnectionResetError`` raised, which is handled separately now.