### PR TITLE
Fix #1411 by adding lookup for new possible user_id format

### DIFF
--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -580,12 +580,11 @@ class PixivBrowser(mechanize.Browser):
 
     def getMyId(self, parsed):
         ''' Assume from main page '''
-        temp = None
         # Possible formats are:
         # pixiv.user.id = "189816";
         # user_id:'189816'
         temp = (re.findall(r"pixiv.user.id = \"(\d+)\";", parsed)
-             or re.findall(r"user_id:\'(\d+)\'", parsed))
+             or re.findall(r"user_id:\s?\'(\d+)\'", parsed))
         if temp is not None and len(temp) > 0:
             self._myId = int(temp[0])
             PixivHelper.print_and_log('info', f'My User Id: {self._myId}.')

--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -581,8 +581,11 @@ class PixivBrowser(mechanize.Browser):
     def getMyId(self, parsed):
         ''' Assume from main page '''
         temp = None
+        # Possible formats are:
         # pixiv.user.id = "189816";
-        temp = re.findall(r"pixiv.user.id = \"(\d+)\";", parsed)
+        # user_id:'189816'
+        temp = (re.findall(r"pixiv.user.id = \"(\d+)\";", parsed)
+             or re.findall(r"user_id:\'(\d+)\'", parsed))
         if temp is not None and len(temp) > 0:
             self._myId = int(temp[0])
             PixivHelper.print_and_log('info', f'My User Id: {self._myId}.')


### PR DESCRIPTION
For some reason request to https://pixiv.net may return page, where user id appear in a "new" format, e.g.
```js
var dataLayer = [{ login: 'yes', gender: '0', user_id: 'USERID', lang: 'en', illustup_flg: 'not_uploaded', premium: 'no', default_service_is_touch: 'no' }]```

Added regexp search for this format into PixivBrowser.getMyId