### PR TITLE
Fix the neglection of local ugoira files when reencoding ugoira

### DIFF
--- a/PixivDownloadHandler.py
+++ b/PixivDownloadHandler.py
@@ -388,7 +388,7 @@ def get_remote_filesize(url, referer, config, notifier=None):
 
 
 def handle_ugoira(image, zip_filename, config, notifier):
-    if not hasattr(image, 'create_ugoira'): # for fanbox zips that can't resolve remote file size
+    if image and not hasattr(image, 'create_ugoira'): # for fanbox zips that can't resolve remote file size
         return
 
     if notifier is None:


### PR DESCRIPTION
# Problem
In current implementation, when reencoding ugoira files, the local ones are neglected.
For function `process_ugoira_local()` in `PixivImageHandler.py`, we have:
```
# Process artwork locally
                    if "ugoira" in extension and not config.overwrite:
                        try:
                            ...
                            PixivDownloadHandler.handle_ugoira(None, str(zip), config, None)
                            ...
```
And in `PixivDownloadHandler.handle_ugoira()`:
```
def handle_ugoira(image, zip_filename, config, notifier):
    if not hasattr(image, 'create_ugoira'): # for fanbox zips that can't resolve remote file size
        return
```
The `image` attribute is clearly set as `None`, and the `handle_ugoira()` function will return immediately before handling local ugoira files.

**Note that the #1412 commit caused this problem; some other potential errors may still exist.**

# Solution
To fix this, we check whether the `image` argument is `None` or not before checking its attribute.
```
 if image and not hasattr(image, 'create_ugoira'): # for fanbox zips that can't resolve remote file size
        return
```