### PR TITLE
Support archive mode for Pixiv artworks

### DIFF
--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -141,6 +141,10 @@ class PixivConfig():
         ConfigItem("Filename", "tagTranslationLocale", "en"),
         ConfigItem("Filename", "customBadChars", "", followup=PixivHelper.parse_custom_sanitizer),
         ConfigItem("Filename", "customCleanUpRe", "", followup=PixivHelper.parse_custom_clean_up_re),
+        ConfigItem("Filename", "createPixivArchive", False),
+        ConfigItem("Filename", "createPixivArchiveCompressionType", "ZIP_STORED",
+                   restriction=lambda algorithm: algorithm in {"ZIP_STORED", "ZIP_DEFLATED", "ZIP_BZIP2", "ZIP_LZMA"}),
+        ConfigItem("Filename", "createPixivArchiveCompressionLevel", 0, restriction=lambda level: level in range(0, 10)),
 
         ConfigItem("Authentication", "username", ""),
         ConfigItem("Authentication", "password", ""),

--- a/PixivImageHandler.py
+++ b/PixivImageHandler.py
@@ -477,31 +477,35 @@ def process_image(caller,
             if is_archive_mode:
                 # Move the files from the temp download directory to a temp zip archive, then move temp zip archive to original target directory.
                 # Make sure that the compression type and level are correct combinations otherwise you'll probably get a RuntimeError.
-                filename = archive_mode_zip_filepath
-                os.makedirs(os.path.dirname(archive_mode_zip_filepath), exist_ok=True)
-                archived_count = 0
-                compression = zipfile.ZIP_STORED
-                match archive_mode_compression_type:
-                    case "ZIP_STORED":
-                        compression = zipfile.ZIP_STORED
-                    case "ZIP_DEFLATED":
-                        compression = zipfile.ZIP_DEFLATED
-                    case "ZIP_BZIP2":
-                        compression = zipfile.ZIP_BZIP2
-                    case "ZIP_LZMA":
-                        compression = zipfile.ZIP_LZMA
-                    case _:
-                        raise ValueError(f'Invalid compression type: {archive_mode_compression_type}')
-                with zipfile.ZipFile(archive_mode_temp_zip_filepath, 'w', compression=compression, compresslevel=archive_mode_compression_level) as zip_file:
-                    _downloaded_dir = os.path.join(archive_mode_temp_download_root_dir, relative_download_dir)
-                    for file in os.listdir(_downloaded_dir):
-                        if not os.path.isfile(os.path.join(_downloaded_dir, file)):
-                            continue
-                        zip_file.write(os.path.join(_downloaded_dir, file), file)
-                        PixivHelper.print_and_log('info', f'Archived: {file}')
-                        archived_count += 1
-                shutil.move(archive_mode_temp_zip_filepath, archive_mode_zip_filepath)
-                PixivHelper.print_and_log('info', f'Moved {archived_count} files to archive: {archive_mode_zip_filepath}')
+                try:
+                    filename = archive_mode_zip_filepath
+                    os.makedirs(os.path.dirname(archive_mode_zip_filepath), exist_ok=True)
+                    archived_count = 0
+                    compression = zipfile.ZIP_STORED
+                    match archive_mode_compression_type:
+                        case "ZIP_STORED":
+                            compression = zipfile.ZIP_STORED
+                        case "ZIP_DEFLATED":
+                            compression = zipfile.ZIP_DEFLATED
+                        case "ZIP_BZIP2":
+                            compression = zipfile.ZIP_BZIP2
+                        case "ZIP_LZMA":
+                            compression = zipfile.ZIP_LZMA
+                        case _:
+                            raise ValueError(f'Invalid compression type: {archive_mode_compression_type}')
+                    with zipfile.ZipFile(archive_mode_temp_zip_filepath, 'w', compression=compression, compresslevel=archive_mode_compression_level) as zip_file:
+                        _downloaded_dir = os.path.join(archive_mode_temp_download_root_dir, relative_download_dir)
+                        for file in os.listdir(_downloaded_dir):
+                            if not os.path.isfile(os.path.join(_downloaded_dir, file)):
+                                continue
+                            zip_file.write(os.path.join(_downloaded_dir, file), file)
+                            PixivHelper.print_and_log('info', f'Archived: {file}')
+                            archived_count += 1
+                    shutil.move(archive_mode_temp_zip_filepath, archive_mode_zip_filepath)
+                    PixivHelper.print_and_log('info', f'Moved {archived_count} files to archive: {archive_mode_zip_filepath}')
+                finally:
+                    # Clean up everything at the end.
+                    shutil.rmtree(archive_mode_temp_dir)
 
         if in_db and not exists:
             result = PixivConstant.PIXIVUTIL_CHECK_DOWNLOAD  # There was something in the database which had not been downloaded

--- a/readme.md
+++ b/readme.md
@@ -769,6 +769,20 @@ Please refer run with `--help` for latest information.
 - customCleanUpRe
   
   TODO.
+- createPixivArchive
+
+  Download Pixiv artworks into an archive, rather than a directory. Uses the [zipfile](https://docs.python.org/3/library/zipfile.html) library. The `.zip` extension need not be added: if the configured filenameformat is `a/b/c/d`, PixivUtil2 will automatically put images into a ZIP archive with path `a/b/c.zip`, such that the contained images have filenameformat `d`. This avoids the need to change existing configuration.
+
+  > When `createPixivArchive = True`, the `pixiv_manga_image.save_name` fields of images within archives will be their basenames instead of their relative or absolute paths in the host filesystem.
+
+- createPixivArchiveCompressionType
+
+  Specify compression algorithm ([ZIP_STORED](https://docs.python.org/3/library/zipfile.html#zipfile.ZIP_STORED), [ZIP_DEFLATED](https://docs.python.org/3/library/zipfile.html#zipfile.ZIP_DEFLATED), [ZIP_BZIP2](https://docs.python.org/3/library/zipfile.html#zipfile.ZIP_BZIP2), or [ZIP_LZMA](https://docs.python.org/3/library/zipfile.html#zipfile.ZIP_LZMA)).
+  Default is ZIP_STORED/no compression.
+- createPixivArchiveCompressionLevel
+
+  Specify compression level. Applies only when using it with ZIP_DEFLATED OR ZIP_BZIP2. Refer to the zipfile documentation on level to algorithm compatibility.
+  Default value is 0.
 
 # Filename Format Syntax
 Available for filenameFormat, filenameMangaFormat, avatarNameFormat, filenameInfoFormat,


### PR DESCRIPTION
Issue: #1416

Allows users to download Pixiv artwork images into an archive using zipfile, instead of to a directory.

To use this, set `createPixivArchive = True`. This will by default create uncompressed archives out of Pixiv artworks. No changes to `filenameformat` are required: the zip archive will be inferred from the leaf directory and given a ".zip" extension.

Customizations on compression are made available by `createPixivArchiveCompressionType` and `createPixivArchiveCompressionLevel`.

Since I don't use Fanbox, this implementation is limited to Pixiv downloads only.

As discussed in the issue, images are first saved to a temp directory, then put into a temp archive, which is finally moved to a persistent archive. This minimizes room for interruptions and partial downloads, ensuring that only completed archives make it to the final destination.

An important archive-mode change to database insertion for images: image save_names in `pixiv_manga_image` table will be the base names of the filenameformat. For example, if in directory mode the image has save name "a/b/c.png", then in archive mode the artwork in `pixiv_master_image` will have save name "a/b.zip" and the image in `pixiv_master_image` will have save name "c.png". I think this is a reasonable interpretation of save name, as it is the image's position within the archive.

I thought about writing a migration script, but considering all the possible configurations, it is probably better not to give a false sense of security...