### PR TITLE
FIX: fanboxGetArtistList to get parseArtistCreatorIDs instead as userID API seems to be failing

### DIFF
--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -985,7 +985,7 @@ class PixivBrowser(mechanize.Browser):
             response = res.read()
             res.close()
 
-            ids = FanboxArtist.parseArtistIds(page=response)
+            ids = FanboxArtist.parseArtistCreatorIDs(page=response)
             return ids
         else:
             raise ValueError(f"Invalid via argument {via}")

--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -1099,7 +1099,7 @@ class PixivBrowser(mechanize.Browser):
         _tzInfo = None
         if self._config.useLocalTimezone:
             _tzInfo = PixivHelper.LocalUTCOffsetTimezone()
-        artist = self.fanboxGetArtistById(js["body"]["user"]["userId"])
+        artist = self.fanboxGetArtistById(js["body"]["creatorId"])
         post = FanboxPost(post_id, artist, js["body"], _tzInfo)
         return post
 

--- a/PixivModelFanbox.py
+++ b/PixivModelFanbox.py
@@ -542,6 +542,22 @@ class FanboxArtist(object):
                 ids.append(creator["user"]["userId"])
         return ids
 
+    @classmethod
+    def parseArtistCreatorIDs(cls, page):
+        ids = list()
+        js = demjson3.decode(page)
+
+        if "error" in js and js["error"]:
+            raise PixivException("Error when requesting Fanbox", 9999, page)
+
+        if "body" in js and js["body"] is not None:
+            js_body = js["body"]
+            if "supportingPlans" in js["body"]:
+                js_body = js_body["supportingPlans"]
+            for creator in js_body:
+                ids.append(creator["creatorId"])
+        return ids
+
     def __init__(self, artist_id, artist_name, creator_id, tzInfo=None):
         self.artistId = int(artist_id)
         self.artistName = artist_name
@@ -571,7 +587,7 @@ class FanboxArtist(object):
 
         if js["body"] is not None:
             js_body = js["body"]
-            
+
             posts = list()
 
             if "creator" in js_body:
@@ -584,7 +600,7 @@ class FanboxArtist(object):
                 # https://www.pixiv.net/ajax/fanbox/post?postId={0}
                 # or old api
                 post_root = js_body
-            
+
 
             #for jsPost in post_root["items"]:
             for jsPost in post_root:


### PR DESCRIPTION
As seen in #1440 discussion the `userId` query param is no longer working thus, changing the code for f1 to get creatorID. TBH, I have not tested f4 as I do not use that function, if anyone out there uses please help to test.
 
Tested on f1 and f3
fixes #1443 , #1440