### PR TITLE
Save series data to DB

### DIFF
--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -157,6 +157,7 @@ class PixivConfig():
         ConfigItem("Pixiv", "autoAddMember", False),
         ConfigItem("Pixiv", "autoAddTag", False),
         ConfigItem("Pixiv", "autoAddCaption", False),
+        ConfigItem("Pixiv", "autoAddSeries", False),
         ConfigItem("Pixiv", "aiDisplayFewer", False),
 
         ConfigItem("FANBOX", "filenameFormatFanboxCover",

--- a/PixivImageHandler.py
+++ b/PixivImageHandler.py
@@ -443,6 +443,17 @@ def process_image(caller,
                                 for locale in tag_data.translation_data:
                                     db.insertTagTranslation(tag_id, locale, tag_data.translation_data[locale])
 
+            # Save series data if enabled.
+            if config.autoAddSeries and (seriesNavData := image.seriesNavData):
+                seriesId = seriesNavData.get("seriesId")
+                seriesType = seriesNavData.get("seriesType")
+                seriesTitle = seriesNavData.get("title")
+                seriesOrder = seriesNavData.get("order")
+                if isinstance(seriesId, str) and seriesId.isdigit() and seriesType and seriesTitle and isinstance(seriesOrder, int):
+                    seriesId = int(seriesId)
+                    db.insertSeries(seriesId, seriesTitle, seriesType)
+                    db.insertImageToSeries(image_id, seriesId, seriesOrder)
+
             # Save member data if enabled
             if image.artist is not None and config.autoAddMember:
                 member_id = image.artist.artistId


### PR DESCRIPTION
This PR adds an option for users to save image series data in the database. Similar to tags, two tables will be created. By default, this functionality is disabled.

This is something I plan to include downstream eventually, but let me know if this is something you'd like to include, or if there are any suggestions/feedback. Thanks