### PR TITLE
Skip AI with cache when download by artist

### DIFF
--- a/PixivDBManager.py
+++ b/PixivDBManager.py
@@ -127,6 +127,16 @@ class PixivDBManager(object):
                             last_update_date DATE,
                             PRIMARY KEY (image_id, tag_id)
                             )""")
+            
+            # image ID is primary key, may not reference to pixiv_master_image as it may not
+            # be downloaded. Used for filtering out AI images.
+            c.execute("""CREATE TABLE IF NOT EXISTS pixiv_ai_info (
+                            image_id INTEGER PRIMARY KEY,
+                            ai_type INTEGER,
+                            created_date DATE,
+                            last_update_date DATE
+            )""")
+
             self.conn.commit()
 
             # Pixiv Series
@@ -1273,6 +1283,39 @@ class PixivDBManager(object):
                         fileExists = True
                         break
         return fileExists
+
+    def insertAiInfo(self, image_id, ai_type):
+        try:
+            c = self.conn.cursor()
+            image_id = int(image_id)
+            ai_type = int(ai_type)
+            c.execute('''INSERT OR IGNORE INTO pixiv_ai_info (image_id, ai_type, created_date, last_update_date) 
+                      VALUES (?, ?, datetime('now'), datetime('now'))
+                      ON CONFLICT(image_id) DO UPDATE SET 
+                      ai_type = excluded.ai_type,
+                      last_update_date = datetime('now')''',
+                      (image_id, ai_type))
+            self.conn.commit()
+        except BaseException:
+            print('Error at insertAiInfo():', str(sys.exc_info()))
+            print('failed')
+            raise
+        finally:
+            c.close()
+    
+    def selectAiTypeByImageId(self, image_id):
+        try:
+            c = self.conn.cursor()
+            image_id = int(image_id)
+            c.execute('''SELECT ai_type FROM pixiv_ai_info WHERE image_id = ?''', (image_id,))
+            result = c.fetchone()
+            return result[0] if result is not None else None
+        except BaseException:
+            print('Error at selectAiTypeByImageId():', str(sys.exc_info()))
+            print('failed')
+            raise
+        finally:
+            c.close()
 
     def cleanUp(self):
         anim_ext = [".zip", ".gif", ".apng", ".ugoira", ".webm"]

--- a/handler/PixivArtistHandler.py
+++ b/handler/PixivArtistHandler.py
@@ -117,6 +117,13 @@ def process_member(caller,
 
             result = PixivConstant.PIXIVUTIL_NOT_OK
             for image_id in artist.imageList:
+
+                # Cached blacklist check
+                ai_type = db.selectAiTypeByImageId(image_id)
+                if ai_type is not None and config.aiDisplayFewer and ai_type == 2:
+                    PixivHelper.print_and_log('warn', f'Skipping image_id: {image_id} – blacklisted due to aiDisplayFewer is set to True and aiType = {ai_type}.')
+                    continue
+
                 ui_prefix = f'{Fore.LIGHTGREEN_EX}[{no_of_images} of {artist.totalImages}]{Style.RESET_ALL} '
                 # PixivHelper.print_and_log(None, ui_prefix)
                 retry_count = 0

--- a/handler/PixivImageHandler.py
+++ b/handler/PixivImageHandler.py
@@ -614,6 +614,9 @@ def process_image(caller,
                     PixivHelper.print_and_log('error', f"Files archived does not match total. Expected {total} but got {archived_count}.")
                     result = PixivConstant.PIXIVUTIL_NOT_OK
 
+        # Save AI type to DB
+        db.insertAiInfo(image_id, image.ai_type)
+
         if in_db and not exists:
             result = PixivConstant.PIXIVUTIL_CHECK_DOWNLOAD  # There was something in the database which had not been downloaded
 


### PR DESCRIPTION
Adds a cache table to pre-emptively skip making repeated API calls to AI-tagged artworks.

If config.aiDisplayFewer is set and user is downloading Pixiv artworks by user, PixivUtil2 will check the local DB to see if the artwork ID's AI type data exists, and perform skip before API call is made. If no record exists, it will store the artwork's AI type data after metadata fetch, to avoid making an API call next time.

See https://github.com/psilabs-dev/PixivUtil2/issues/22 for downstream issue/use case. Though this does involve creating a new table just to skip, so I can understand if it's not worth it but feel free to leave feedback.