### PR TITLE
Add database migrations

### DIFF
--- a/PixivDBManager.py
+++ b/PixivDBManager.py
@@ -86,7 +86,7 @@ class PixivDBManager(object):
             toMigrate = [item for item in files if item not in migratedFiles]
 
             # perform migrations
-            for file in toMigrate:
+            for file in sorted(toMigrate):
                 PixivDBManager.applyMigration(migrationDir, file, self.conn)
             
             print("Done!")

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -1694,7 +1694,7 @@ def main():
 
     try:
         __dbManager__ = PixivDBManager(root_directory=__config__.rootDirectory, target=__config__.dbPath)
-        __dbManager__.createDatabase()
+        __dbManager__.migrateDatabase()
 
         if __config__.useList:
             PixivListHandler.import_list(sys.modules[__name__], __config__, 'list.txt')

--- a/migrations/000_init.sql
+++ b/migrations/000_init.sql
@@ -1,0 +1,107 @@
+CREATE TABLE IF NOT EXISTS pixiv_master_member (
+    member_id INTEGER PRIMARY KEY ON CONFLICT IGNORE,
+    name TEXT,
+    save_folder TEXT,
+    created_date DATE,
+    last_update_date DATE,
+    last_image INTEGER
+);
+
+-- add column isDeleted
+-- 0 = false, 1 = true
+ALTER TABLE
+    pixiv_master_member
+ADD
+    COLUMN is_deleted INTEGER DEFAULT 0;
+
+-- add column for artist token
+ALTER TABLE
+    pixiv_master_member
+ADD
+    COLUMN member_token TEXT;
+
+CREATE TABLE IF NOT EXISTS pixiv_master_image (
+    image_id INTEGER PRIMARY KEY,
+    member_id INTEGER,
+    title TEXT,
+    save_name TEXT,
+    created_date DATE,
+    last_update_date DATE
+);
+
+-- add column isManga
+ALTER TABLE
+    pixiv_master_image
+ADD
+    COLUMN is_manga TEXT;
+
+-- add column caption
+ALTER TABLE
+    pixiv_master_image
+ADD
+    COLUMN caption TEXT;
+
+CREATE TABLE IF NOT EXISTS pixiv_manga_image (
+    image_id INTEGER,
+    page INTEGER,
+    save_name TEXT,
+    created_date DATE,
+    last_update_date DATE,
+    PRIMARY KEY (image_id, page)
+);
+
+-- Pixiv Tags
+CREATE TABLE IF NOT EXISTS pixiv_master_tag (
+    tag_id VARCHAR(255) PRIMARY KEY,
+    created_date DATE,
+    last_update_date DATE
+);
+
+CREATE TABLE IF NOT EXISTS pixiv_tag_translation (
+    tag_id VARCHAR(255) REFERENCES pixiv_master_tag(tag_id),
+    translation_type VARCHAR(255),
+    translation VARCHAR(255),
+    created_date DATE,
+    last_update_date DATE,
+    PRIMARY KEY (tag_id, translation_type)
+);
+
+-- FANBOX
+CREATE TABLE IF NOT EXISTS fanbox_master_post (
+    member_id INTEGER,
+    post_id INTEGER PRIMARY KEY ON CONFLICT IGNORE,
+    title TEXT,
+    fee_required INTEGER,
+    published_date DATE,
+    updated_date DATE,
+    post_type TEXT,
+    last_update_date DATE
+);
+
+CREATE TABLE IF NOT EXISTS fanbox_post_image (
+    post_id INTEGER,
+    page INTEGER,
+    save_name TEXT,
+    created_date DATE,
+    last_update_date DATE,
+    PRIMARY KEY (post_id, page)
+);
+
+-- Sketch
+CREATE TABLE IF NOT EXISTS sketch_master_post (
+    member_id INTEGER,
+    post_id INTEGER PRIMARY KEY ON CONFLICT IGNORE,
+    title TEXT,
+    published_date DATE,
+    updated_date DATE,
+    post_type TEXT,
+    last_update_date DATE
+);
+CREATE TABLE IF NOT EXISTS sketch_post_image (
+    post_id INTEGER,
+    page INTEGER,
+    save_name TEXT,
+    created_date DATE,
+    last_update_date DATE,
+    PRIMARY KEY (post_id, page)
+);

--- a/migrations/001_save_series.sql
+++ b/migrations/001_save_series.sql
@@ -1,0 +1,19 @@
+-- Pixiv Series
+CREATE TABLE IF NOT EXISTS pixiv_master_series (
+    series_id VARCHAR(255) PRIMARY KEY,
+    series_title VARCHAR(255),
+    series_type VARCHAR(255),
+    series_description TEXT,
+    created_date DATE,
+    last_update_date DATE
+);
+
+CREATE TABLE IF NOT EXISTS pixiv_image_to_series (
+    series_id VARCHAR(255) REFERENCES pixiv_master_series(series_id),
+    series_order INTEGER,
+    image_id INTEGER REFERENCES pixiv_master_image(image_id),
+    created_date DATE,
+    last_update_date DATE,
+    PRIMARY KEY (series_id, series_order),
+    UNIQUE (image_id)
+);

--- a/migrations/002_ai_info.sql
+++ b/migrations/002_ai_info.sql
@@ -1,0 +1,8 @@
+-- image ID is primary key, may not reference to pixiv_master_image as it may not
+-- be downloaded. Used for filtering out AI images.
+CREATE TABLE IF NOT EXISTS pixiv_ai_info (
+    image_id INTEGER PRIMARY KEY,
+    ai_type INTEGER,
+    created_date DATE,
+    last_update_date DATE
+);

--- a/test/test_PixivDBManager.py
+++ b/test/test_PixivDBManager.py
@@ -14,7 +14,7 @@ PixivConstant.PIXIVUTIL_LOG_FILE = 'pixivutil.test.log'
 class TestPixivDBManager(unittest.TestCase):
     def test_ImportListTxt(self):
         DB = PixivDBManager(root_directory=".", target="test.db.sqlite")
-        DB.createDatabase()
+        DB.migrateDatabase()
         members = PixivListItem.parseList("test.list.txt", root_directory)
         result = DB.importList(members)
         # self.assertEqual(result, 0)
@@ -22,7 +22,7 @@ class TestPixivDBManager(unittest.TestCase):
 
     def test_SelectMembersByLastDownloadDate(self):
         DB = PixivDBManager(root_directory=".", target="test.db.sqlite")
-        DB.createDatabase()
+        DB.migrateDatabase()
         result = DB.selectMembersByLastDownloadDate(7)
         # self.assertEqual(len(result), LIST_SIZE)
         assert len(result) == LIST_SIZE
@@ -31,7 +31,7 @@ class TestPixivDBManager(unittest.TestCase):
 
     def test_SelectAllMember(self):
         DB = PixivDBManager(root_directory=".", target="test.db.sqlite")
-        DB.createDatabase()
+        DB.migrateDatabase()
         result = DB.selectAllMember()
         # self.assertEqual(len(result), LIST_SIZE)
         assert len(result) == LIST_SIZE


### PR DESCRIPTION
Maybe the project is not updated often, but it is annoying that every single update I have to delete the database and config. So I made that at least you can keep the database. This will also help people who are updating PixivUtil2 via git.

If you are developer, every time the database is changed, you have to create new `.sql` file in `migrations` directory (for example: `002_ai_info.sql`). The template for the filename is `XXX_short_description.sql`, where XXX is incremental migration number (it decides the order of migrations) and short description tells us what has changed in the migration.

Before this branch is merged I could add some python script to help users that have already used PixivUtil2 before to mark migrations as done.