### PR TITLE
checkUpdatedLimit check for FANBOX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ dist*/*
 old/*
 config.ini
 config.ini.error*
-list.txt
+listfanbox.txt
 *.log
 *.bat
 db.sqlite

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ Please refer run with `--help` for latest information.
   - When this is `False`, posts will be processed anyways.
 - checkUpdatedLimitFanbox
 
-  Skip to next FANBOX member if already seen n-number of previously processed/unchanged posts for current member while `checkDBProcessHistory` is enabled.
+  Skip to next FANBOX member if a number of consecutive previously processed/unchanged posts are encountered for the current member while `checkDBProcessHistory` is enabled.
   Set to `0` to disable.
 - listPathFanbox
 

--- a/README.md
+++ b/README.md
@@ -405,7 +405,11 @@ Please refer run with `--help` for latest information.
 - checkDBProcessHistory
   Each FANBOX post has a updated_date value, which will be recorded/updated in database after it is processed.
   - When this is `True`, the values in database would be checked when processing each post. If record is no earlier than the newly retrieved date, which means that the post has not been processed at all or changed since last time, the post would be skipped.
+  - Can be combined with `checkUpdatedLimitFanbox` to stop checking more posts for the current FANBOX member after enough unchanged/already-processed posts are encountered.
   - When this is `False`, posts will be processed anyways.
+- checkUpdatedLimitFanbox
+  Skip to next FANBOX member if already see n-number of previously processed/unchanged posts for current member while `checkDBProcessHistory` is enabled.
+  Set `0` to disable.
 - listPathFanbox
 
   The list file for fanbox creators. One creator per line.

--- a/README.md
+++ b/README.md
@@ -403,13 +403,15 @@ Please refer run with `--help` for latest information.
 
   Set to `True` to download FANBOX post cover images even if they are restricted.
 - checkDBProcessHistory
+
   Each FANBOX post has a updated_date value, which will be recorded/updated in database after it is processed.
   - When this is `True`, the values in database would be checked when processing each post. If record is no earlier than the newly retrieved date, which means that the post has not been processed at all or changed since last time, the post would be skipped.
   - Can be combined with `checkUpdatedLimitFanbox` to stop checking more posts for the current FANBOX member after enough unchanged/already-processed posts are encountered.
   - When this is `False`, posts will be processed anyways.
 - checkUpdatedLimitFanbox
-  Skip to next FANBOX member if already see n-number of previously processed/unchanged posts for current member while `checkDBProcessHistory` is enabled.
-  Set `0` to disable.
+
+  Skip to next FANBOX member if already seen n-number of previously processed/unchanged posts for current member while `checkDBProcessHistory` is enabled.
+  Set to `0` to disable.
 - listPathFanbox
 
   The list file for fanbox creators. One creator per line.

--- a/common/PixivConfig.py
+++ b/common/PixivConfig.py
@@ -178,6 +178,7 @@ class PixivConfig():
         ConfigItem("FANBOX", "downloadCoverWhenRestricted", False),
         ConfigItem("FANBOX", "downloadCover", True),
         ConfigItem("FANBOX", "checkDBProcessHistory", False),
+        ConfigItem("FANBOX", "checkUpdatedLimitFanbox", 0),
         ConfigItem("FANBOX", "listPathFanbox", "listfanbox.txt"),
 
         ConfigItem("FFmpeg", "ffmpeg", "ffmpeg.exe"),

--- a/handler/PixivFanboxHandler.py
+++ b/handler/PixivFanboxHandler.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import gc
 
 import common.datetime_z as datetime_z
 import common.PixivBrowserFactory as PixivBrowserFactory
@@ -43,6 +44,7 @@ def process_fanbox_artist_by_id(caller, config, artist_id, end_page, title_prefi
     current_page = 1
     next_url = None
     image_count = 1
+    updated_limit_count = 0
     while True:
         PixivHelper.print_and_log("info", "Processing {0}, page {1}".format(artist, current_page))
         caller.set_console_title(f"{title_prefix} {artist}, page {current_page}")
@@ -59,7 +61,7 @@ def process_fanbox_artist_by_id(caller, config, artist_id, end_page, title_prefi
             # images
             if post.type in PixivModelFanbox.FanboxPost._supportedType:
                 try:
-                    process_fanbox_post(caller, config, post, artist)
+                    result = process_fanbox_post(caller, config, post, artist)
                 except KeyboardInterrupt:
                     choice = input("Keyboard Interrupt detected, continue to next post? (Y/N)").rstrip("\r")
                     if choice.upper() == 'N':
@@ -67,6 +69,20 @@ def process_fanbox_artist_by_id(caller, config, artist_id, end_page, title_prefi
                         return
                     else:
                         continue
+                # Similar behavior to Pixiv's checkUpdatedLimit skip
+                # If we keep encountering already downloaded posts, skip the rest for this creator.
+                if result == PixivConstant.PIXIVUTIL_SKIP_DUPLICATE:
+                    updated_limit_count += 1
+                    if (config.checkUpdatedLimitFanbox != 0 and updated_limit_count >= config.checkUpdatedLimitFanbox):
+                        PixivHelper.print_and_log(
+                                "info",
+                                f"Skipping FANBOX member: {artist.artistId}\n" +
+                                f"(reached checkUpdatedLimitFanbox={config.checkUpdatedLimitFanbox})")
+                        PixivBrowserFactory.getBrowser().clear_history()
+                        return
+                    gc.collect()
+                elif result == PixivConstant.PIXIVUTIL_OK:
+                    updated_limit_count = 0
             else:
                 PixivHelper.print_and_log("info", f"Unsupported post type: {post.imageId} => {post.type}")
             image_count += 1
@@ -147,11 +163,11 @@ def process_fanbox_post(caller, config, post: PixivModelFanbox.FanboxPost, artis
 
         if post.is_restricted:
             PixivHelper.print_and_log("info", "Skipping post: {0} due to restricted post.".format(post.imageId))
-            return
+            return PixivConstant.PIXIVUTIL_SKIP_BLACKLIST
 
         if flag_processed:
             PixivHelper.print_and_log("info", "Skipping post: {0} because it was downloaded before.".format(post.imageId))
-            return
+            return PixivConstant.PIXIVUTIL_SKIP_DUPLICATE
 
         if post.images is None or len(post.images) == 0:
             PixivHelper.print_and_log("info", "No Image available in post: {0}.".format(post.imageId))
@@ -235,6 +251,7 @@ def process_fanbox_post(caller, config, post: PixivModelFanbox.FanboxPost, artis
             db.insertPostImages(post_files)
 
     db.updatePostUpdateDate(post.imageId, post.updatedDate)
+    return PixivConstant.PIXIVUTIL_OK
 
 
 def process_pixiv_by_fanbox_id(caller, config, artist_id, start_page=1, end_page=0, tags=None, title_prefix=""):


### PR DESCRIPTION
Similar patch to #753 

Adds a new config item `checkUpdatedLimitFanbox` which behaves similarly to `checkUpdatedLimit`.

When _checkUpdatedLimitFanbox_ previously downloaded posts are encountered, PixivUtil2 skips to the next creator in the list.
`checkDBProcessHistory` must be True, as this check uses that check to determine previously downloaded posts.

When `checkUpdatedLimitFanbox` is 0 or `checkDBProcessHistory` is False, this behavior is disabled.