### PR TITLE
Add Docker Compose workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@
 
 # Docker
 
+The image installs Python dependencies and FFmpeg; your clone is bind-mounted at `/workdir` at run time (the Dockerfile does not copy the app source).
+
+**Docker Compose (uses `Dockerfile` + `compose.yaml`):**
+
+```sh
+$ docker compose build
+$ docker compose run --rm -it pixivutil2
+```
+
+**Plain Docker:**
+
 ```sh
 $ docker build -t pixivutil2 .
 $ docker run -it --rm \
@@ -145,7 +156,7 @@ Q9. The downloaded images are corrupted, how to redownload it again?
       from databases (enter d, followed by 10).
     - Or, you can set alwaysCheckFileSize = True and verifyimage = True in config.ini
       and retry the download.
-      
+
 Q10. I got this error またはメールアドレス、パスワードが正しいかチェックしてください。
     - Use your email address for the username, or check your password in config.ini
 
@@ -337,7 +348,7 @@ Please refer run with `--help` for latest information.
 - numberofpage
 
   Number of page to be processed, put `0` to process all pages.
-  
+
 - r18mode
 
   Only list images tagged R18, for member, member's bookmark, and search by tag. Set to `True` to enable.
@@ -428,7 +439,7 @@ Please refer run with `--help` for latest information.
   - `socks5://<username>:<password>@<proxy_server>:<port>` or
   - `socks4://<username>:<password>@<proxy_server>:<port>`
 - useragent
-  
+
   Browser user agent to spoof. You can check it from https://www.whatismybrowser.com/detect/what-is-my-user-agent
 - userobots
 
@@ -562,7 +573,7 @@ Please refer run with `--help` for latest information.
 
   Remove all HTML tags and their contents from the image caption/description when writing metadata to files. The contents of any links will be lost, so consider enabling writeUrlInDescription to retain them.
 - urlBlacklistRegex
-  
+
   Used to filter out the url in the description using regular expression.
 - dbPath
 
@@ -636,7 +647,7 @@ Please refer run with `--help` for latest information.
   Skip downloading if the remote size is not known when `alwaysCheckFileSize` is set to True.
 
 - enablePostProcessing
-  
+
   If true, it enabled post processing cmd for every downloaded files. Default: False.
 
 - postProcessingCmd
@@ -677,7 +688,7 @@ Please refer run with `--help` for latest information.
 
   Codec to be used for encoding, default is using `libvpx-vp9`.
 - ffmpegExt
-  
+
   The file extension (container format) to use for encoding. default: `webm`.
 - ffmpegparam
 
@@ -785,7 +796,7 @@ Please refer run with `--help` for latest information.
   For sanitizing filenames with custom rules. Supports regular expressions.
   For detailed syntax, please refer to 'Bad chars' section.
 - customCleanUpRe
-  
+
   TODO.
 
 # Filename Format Syntax
@@ -960,7 +971,7 @@ http://www.pixiv.net/member_illust.php?id=123456
 - Currently available syntaxes are:
 ```
 -> %coverImage%
-   A 'div' tag with its 'class' set to 'cover', and a child 'img' tag with 
+   A 'div' tag with its 'class' set to 'cover', and a child 'img' tag with
    the url to the cover image as its 'src' attribute.
 -> %coverImageUrl%
    Simply the url to the cover image in clear text.
@@ -987,7 +998,7 @@ http://www.pixiv.net/member_illust.php?id=123456
    A 'div' tag with its 'class' set to 'non-article text' and all paragraphs
    of text put in 'p' tags as its children tokens.
 ```
-- If there is a 'div' tag with 'main' in its 'class' in the template, 'article' or 
+- If there is a 'div' tag with 'main' in its 'class' in the template, 'article' or
   'non-article' would be appended to its 'class' depending on the type of the post.
 
 # Bad chars

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,10 @@
+services:
+  pixivutil2:
+    build: .
+    image: pixivutil2
+    volumes:
+      - .:/workdir
+    working_dir: /workdir
+    stdin_open: true
+    tty: true
+    command: ["python", "PixivUtil2.py"]


### PR DESCRIPTION
Add a `compose.yaml` that builds from the existing `Dockerfile`, bind-mounts the repository at `/workdir`, sets the working directory, allocates a TTY for the interactive menu, and runs `python PixivUtil2.py`.

Update the README Docker section to document `docker compose build` and `docker compose run --rm -it pixivutil2`, keep the plain `docker build` / `docker run` instructions, and clarify that the image only installs dependencies and FFmpeg while the app code comes from the bind mount at run time.

**Tested:** `docker compose build` and `docker compose run --rm -it pixivutil2` from the repository root.