### PR TITLE
Fix HTTP 400 on image bookmarks when Pixiv language is set to English (issue #1513)

### DIFF
--- a/handler/PixivBookmarkHandler.py
+++ b/handler/PixivBookmarkHandler.py
@@ -416,9 +416,16 @@ def get_image_bookmark(caller, config, hide, start_page=1, end_page=0, tag=None,
         offset = limit * (i - 1)
         PixivHelper.print_and_log('info', f"Importing user's bookmarked image from page {i}")
 
-        url = f"https://www.pixiv.net/ajax/user/{member_id}/illusts/bookmarks?tag={encoded_tag}&offset={offset}&limit={limit}&rest={show}"
+        locale = ""
+        if br._locale is not None and len(br._locale) > 0:
+            if br._locale[0] == "/":
+                locale = f"&lang={br._locale[1:]}"
+            else:
+                locale = f"&lang={br._locale}"
+
+        url = f"https://www.pixiv.net/ajax/user/{member_id}/illusts/bookmarks?tag={encoded_tag}&offset={offset}&limit={limit}&rest={show}{locale}"
         if use_image_tag:  # don't filter based on user's bookmark tag
-            url = f"https://www.pixiv.net/ajax/user/{member_id}/illusts/bookmarks?tag=&offset={offset}&limit={limit}&rest={show}"
+            url = f"https://www.pixiv.net/ajax/user/{member_id}/illusts/bookmarks?tag=&offset={offset}&limit={limit}&rest={show}{locale}"
             PixivHelper.print_and_log('info', f"Using image tag: {tag}")
 
         PixivHelper.print_and_log('info', f"Source URL: {url}")


### PR DESCRIPTION
## Summary

Fixes #1513

When the Pixiv account language is set to English, `br._locale` is set to `"/en"` after login. The `get_image_bookmark()` function in `handler/PixivBookmarkHandler.py` was building the bookmarks API URL **without** a `lang` query parameter, causing Pixiv's API to reject the request with `HTTP 400 Bad Request`.

Every other API caller in the codebase (`getFollowedNewIllusts`, `getNewIllusts`, `getMangaSeries`, etc.) already handles this correctly by stripping the leading `/` from `_locale` and appending `&lang=...` to the URL. `get_image_bookmark()` was the only one missing this.

## Change

```python
# Before
url = f"...bookmarks?tag={encoded_tag}&offset={offset}&limit={limit}&rest={show}"

# After — same locale pattern used by getFollowedNewIllusts and others
locale = ""
if br._locale is not None and len(br._locale) > 0:
    if br._locale[0] == "/":
        locale = f"&lang={br._locale[1:]}"
    else:
        locale = f"&lang={br._locale}"

url = f"...bookmarks?tag={encoded_tag}&offset={offset}&limit={limit}&rest={show}{locale}"
```

Both URL variants (normal and `use_image_tag`) now include the locale parameter.

## Test plan

- [ ] Run image bookmark download with Pixiv account language set to **English** — should no longer return 400
- [ ] Run image bookmark download with Pixiv account language set to **Japanese** — should continue to work (locale is empty string, no `lang` param appended)
- [ ] Run with tag filter and `use_image_tag` flag — both URL paths covered

---

> Diagnosed and fixed with [Claude Code](https://claude.ai/code) (Anthropic Claude Sonnet 4.6 AI assistant).