### PR TITLE
FIX: fanbox downloading failed

### DIFF
--- a/common/PixivBrowserFactory.py
+++ b/common/PixivBrowserFactory.py
@@ -9,29 +9,29 @@ import socket
 import sys
 import time
 import traceback
+from typing import List, Literal, Tuple, Union
 from urllib.error import HTTPError
 from urllib.parse import urlparse
 from urllib.request import Request
-from typing import List, Literal, Tuple, Union
 
+import curl_cffi
 import demjson3
 import mechanize
 import socks
 from bs4 import BeautifulSoup
 from colorama import Fore, Style
-import curl_cffi
 
 import common.PixivHelper as PixivHelper
+from common.PixivException import PixivException
+from common.PixivOAuth import PixivOAuth
 from model.PixivArtist import PixivArtist
 from model.PixivBookmark import PixivNewIllustBookmark
-from common.PixivException import PixivException
 from model.PixivImage import PixivImage, PixivMangaSeries
 from model.PixivModelFanbox import FanboxArtist, FanboxPost
 from model.PixivModelSketch import SketchArtist, SketchPost
 from model.PixivNovel import MAX_LIMIT, NovelSeries, PixivNovel
-from common.PixivOAuth import PixivOAuth
 from model.PixivRanking import PixivNewIllust, PixivRanking
-from model.PixivTags import PixivTags, PixivTag
+from model.PixivTags import PixivTag, PixivTags
 
 defaultCookieJar = None
 defaultConfig = None
@@ -1142,8 +1142,11 @@ class PixivBrowser(mechanize.Browser):
 
     def fanboxUpdatePost(self, post: FanboxPost):
         js = self.fanboxGetPostJsonById(post.imageId, post.parent)
-        post.parsePost(js["body"])
-        post.parse_post_details(js["body"])
+        data = js["body"]
+        if "post" in data:  # new API response as of 2026-07-25
+            data = data["post"]
+        post.parsePost(data)
+        post.parse_post_details(data)
 
     def fanboxGetPostById(self, post_id):
         js = self.fanboxGetPostJsonById(post_id)

--- a/model/PixivModelFanbox.py
+++ b/model/PixivModelFanbox.py
@@ -555,7 +555,18 @@ class FanboxArtist(object):
             if "supportingPlans" in js["body"]:
                 js_body = js_body["supportingPlans"]
             for creator in js_body:
-                ids.append(creator["creatorId"])
+                if isinstance(creator, dict): # this is the old API, not sure if this is still used, but just in case
+                    ids.append(creator["creatorId"])
+                else:
+                    if "plans" in js_body:  # new API response as of 2026-07-25
+                        for plan in js_body["plans"]:
+                            ids.append(plan["creatorId"])
+                    else:
+                        raise PixivException(
+                            "Error when requesting Fanbox, no plans found",
+                            9999,
+                            js_body,
+                        )
         return ids
 
     def __init__(self, artist_id, artist_name, creator_id, tzInfo=None):
@@ -577,6 +588,9 @@ class FanboxArtist(object):
 
         if js["body"] is not None:
             js_body = js["body"]
+            if isinstance(js_body, dict):
+                if "pageUrls" in js_body: # new API response as of 2026-07-25
+                    js_body = js_body["pageUrls"]
             self.Pages = js_body
 
     def parsePosts(self, page) -> List[FanboxPost]:
@@ -600,6 +614,8 @@ class FanboxArtist(object):
                 # https://www.pixiv.net/ajax/fanbox/post?postId={0}
                 # or old api
                 post_root = js_body
+                if "posts" in js_body: # new api as of 2026-07-25
+                    post_root = js_body["posts"]
 
             # for jsPost in post_root["items"]:
             for jsPost in post_root:


### PR DESCRIPTION
Not sure if I'm the only one facing this issue.
There are a bunch of API response changes, where it returns dict in dicts.
As much as possible I should have kept the original logic. 
Anyone else do help to validate if your API still returns the old version.

tested using:
`PixivUtil2.py -x -s f1 --ep 1`

Should fix: 
#1538 