### PR TITLE
Fix _myId staying 0 when the x-userid login fast path is taken (bookmarks HTTP 400)

### DIFF
--- a/common/PixivBrowserFactory.py
+++ b/common/PixivBrowserFactory.py
@@ -385,6 +385,8 @@ class PixivBrowser(mechanize.Browser):
             x_uid = headers.get('x-userid') or headers.get('X-UserId') or headers.get('X-Userid')
             if x_uid:
                 PixivHelper.print_and_log('info', f'Login recognized by server (x-userid={x_uid}).')
+                self._myId = int(x_uid)
+                PixivHelper.print_and_log('info', f'My User Id: {self._myId}.')
                 return True
 
             res = self.open_with_retry('https://www.pixiv.net')  # + self._locale)


### PR DESCRIPTION
## Problem

Downloading your own bookmarks (menu option 6) fails immediately with HTTP 400:

```
Importing user's bookmarked image from page 1
Source URL: https://www.pixiv.net/ajax/user/0/illusts/bookmarks?tag=&offset=0&limit=48&rest=show
Error at process_image_bookmark(): ... <HTTPError 400: 'Bad Request'>
```

Note the URL: `user/0`. The request is built for user ID **0**, so Pixiv rejects it.

## Cause

`cookieLogin()` has a fast path that confirms login from the `x-userid` response header:

```python
x_uid = headers.get('x-userid') or headers.get('X-UserId') or headers.get('X-Userid')
if x_uid:
    PixivHelper.print_and_log('info', f'Login recognized by server (x-userid={x_uid}).')
    return True
```

It returns `True` without ever assigning `self._myId`, and every assignment to `_myId` lives further down in the slow HTML-scraping path that this `return` skips. `_myId` therefore keeps its class default of `0` while login is reported as successful. The `if self._myId == 0:` guard further down, which exists to catch exactly this, is skipped too.

Anything reading `br._myId` then builds a request for user 0 — the bookmarks endpoint above being the visible case.

The fast path was added in #1493; the ID is sitting right there in the header it already inspects, it just was not stored.

## Fix

Assign `_myId` from the header before returning, and log it the same way the other paths do:

```python
if x_uid:
    PixivHelper.print_and_log('info', f'Login recognized by server (x-userid={x_uid}).')
    self._myId = int(x_uid)
    PixivHelper.print_and_log('info', f'My User Id: {self._myId}.')
    return True
```

Two lines, confined to the branch that was missing them. The slow path is untouched.

## Testing

The log makes the before/after unambiguous. Without the fix, the fast path logs recognition and nothing else:

```
INFO - Login recognized by server (x-userid=11223344).
```

With the fix, the ID is captured:

```
INFO - Login recognized by server (x-userid=11223344).
INFO - My User Id: 11223344.
```

and bookmark downloading proceeds normally instead of 400ing on the first page — verified over several hundred bookmarked images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
