### PR TITLE
Keep animated gif avatars animated (#1508)

### DIFF
--- a/model/PixivArtist.py
+++ b/model/PixivArtist.py
@@ -7,6 +7,21 @@ from bs4 import BeautifulSoup
 from common.PixivException import PixivException
 
 
+def get_original_avatar_url(url):
+    '''Strip the size suffix from an avatar url to get the original image.
+
+    Issue #1508: an animated gif avatar only keeps its frames in the resized
+    variants, the unsuffixed original is a single static frame. Fall back to
+    the largest animated size (_170) for gif, the size suffix is still
+    stripped for every other format.
+    '''
+    if url is None:
+        return url
+    if url.lower().endswith(".gif"):
+        return url.replace("_50.", "_170.")
+    return url.replace("_50.", ".").replace("_170.", ".")
+
+
 class PixivArtist:
     '''Class for parsing member page.'''
 
@@ -97,7 +112,7 @@ class PixivArtist:
 
                         avatar_data = data["user"]["profile_image_urls"]
                         if avatar_data is not None and "medium" in avatar_data:
-                            self.artistAvatar = avatar_data["medium"].replace("_170", "")
+                            self.artistAvatar = get_original_avatar_url(avatar_data["medium"])
 
                 if "profile" in page:
                     if self.totalImages == 0:
@@ -112,7 +127,7 @@ class PixivArtist:
         root = page
 
         self.artistId = root["userId"]
-        self.artistAvatar = root["image"].replace("_50.", ".").replace("_170.", ".")
+        self.artistAvatar = get_original_avatar_url(root["image"])
         self.artistName = root["name"]
 
         if root["background"] is not None:
@@ -134,9 +149,9 @@ class PixivArtist:
             self.artistId = root["userId"]
             self.artistName = root["name"]
             if "imageBig" in root and root["imageBig"] is not None:
-                self.artistAvatar = payload["body"]["imageBig"].replace("_50.", ".").replace("_170.", ".")
+                self.artistAvatar = get_original_avatar_url(payload["body"]["imageBig"])
             elif "image" in root and root["image"] is not None:
-                self.artistAvatar = root["image"].replace("_50.", ".").replace("_170.", ".")
+                self.artistAvatar = get_original_avatar_url(root["image"])
 
             # https://www.pixiv.net/ajax/user/1893126
             if "background" in root and root["background"] is not None:

--- a/test/test_PixivModel.py
+++ b/test/test_PixivModel.py
@@ -6,7 +6,7 @@ import unittest
 
 import common.PixivConstant as PixivConstant
 # import PixivHelper
-from model.PixivArtist import PixivArtist
+from model.PixivArtist import PixivArtist, get_original_avatar_url
 from model.PixivBookmark import PixivBookmark, PixivNewIllustBookmark
 from common.PixivBrowserFactory import PixivBrowser
 from common.PixivException import PixivException
@@ -106,6 +106,50 @@ class TestPixivArtist(unittest.TestCase):
     #     # self.assertEqual(artist.artistToken, 'nandaka')
     #     self.assertGreaterEqual(artist.totalImages, 1)
     #     self.assertIn(65079382, artist.imageList)
+
+    # Issue #1508
+    def testGetOriginalAvatarUrlStatic(self):
+        base = "https://i.pximg.net/user-profile/img/2018/01/01/00/00/00/11223344_0123456789abcdef"
+        # the unsuffixed original is the biggest version for a static avatar
+        self.assertEqual(get_original_avatar_url(f"{base}_50.jpg"), f"{base}.jpg")
+        self.assertEqual(get_original_avatar_url(f"{base}_170.jpg"), f"{base}.jpg")
+        self.assertEqual(get_original_avatar_url(f"{base}_170.png"), f"{base}.png")
+        self.assertEqual(get_original_avatar_url(f"{base}.png"), f"{base}.png")
+
+    # Issue #1508
+    def testGetOriginalAvatarUrlAnimatedGif(self):
+        base = "https://i.pximg.net/user-profile/img/2018/01/01/00/00/00/11223344_0123456789abcdef"
+        # the unsuffixed original of a gif avatar is a single static frame,
+        # _170 is the biggest one that keeps the animation.
+        self.assertEqual(get_original_avatar_url(f"{base}_50.gif"), f"{base}_170.gif")
+        self.assertEqual(get_original_avatar_url(f"{base}_170.gif"), f"{base}_170.gif")
+        self.assertEqual(get_original_avatar_url(f"{base}_170.GIF"), f"{base}_170.GIF")
+
+    def testGetOriginalAvatarUrlNone(self):
+        self.assertIsNone(get_original_avatar_url(None))
+
+    # Issue #1508
+    def testParseBackgroundKeepAnimatedAvatar(self):
+        base = "https://i.pximg.net/user-profile/img/2018/01/01/00/00/00/11223344_0123456789abcdef"
+        payload = {"body": {"userId": "11223344",
+                            "name": "example_user",
+                            "image": f"{base}_50.gif",
+                            "imageBig": f"{base}_170.gif",
+                            "background": None}}
+        artist = PixivArtist(11223344)
+        artist.ParseBackground(payload)
+        self.assertEqual(artist.artistAvatar, f"{base}_170.gif")
+
+    def testParseBackgroundStaticAvatar(self):
+        base = "https://i.pximg.net/user-profile/img/2018/01/01/00/00/00/11223344_0123456789abcdef"
+        payload = {"body": {"userId": "11223344",
+                            "name": "example_user",
+                            "image": f"{base}_50.jpg",
+                            "imageBig": f"{base}_170.jpg",
+                            "background": None}}
+        artist = PixivArtist(11223344)
+        artist.ParseBackground(payload)
+        self.assertEqual(artist.artistAvatar, f"{base}.jpg")
 
 
 class TestPixivImage(unittest.TestCase):


### PR DESCRIPTION
Fixes #1508.

## Cause

The avatar url returned by the API carries a size suffix, and it is stripped to
fetch the full size original:

```python
self.artistAvatar = payload["body"]["imageBig"].replace("_50.", ".").replace("_170.", ".")
```

For an animated gif avatar that "original" is a single static frame — pixiv only
keeps the animation in the resized variants. Downloading all three variants of a
gif avatar and decoding them with Pillow:

| url | HTTP | size | frames |
| --- | --- | --- | --- |
| `…/<id>_<hash>_50.gif` | 200 | 50x38 | **10 (animated)** |
| `…/<id>_<hash>_170.gif` | 200 | 170x128 | **10 (animated)** |
| `…/<id>_<hash>.gif` | 200 | 400x300 | **1 (static)** |

So the saved file really is a valid gif with exactly one frame, which matches the
report. Nothing downstream re-encodes it — `process_avatar_bg()` passes the
rewritten url straight to `download_image()`.

I probed the other suffixes on the same avatar (`_16`, `_32`, `_64`, `_100`,
`_128`, `_180`, `_200`, `_256`, `_400`, `_500`): only `_16`, `_50` and `_170`
exist, everything else 404s. `_170` is therefore the largest animated version
available — there is no animated original to fetch.

The stripping is correct for static avatars, so it should not just be removed. On
a `.png` avatar the unsuffixed original is 240x243 versus 168x170 for `_170`.

## Change

The rewrite moves into `get_original_avatar_url()` in `model/PixivArtist.py`,
replacing the four inline copies (`ParseInfo`, `ParseInfoFromImage`, and both
branches of `ParseBackground`). It keeps `_170` for `.gif` and strips the suffix
for every other format as before.

This trades resolution for the animation on gif avatars (170x128 animated instead
of 400x300 static). That seemed the right way round given the file is meant to be
an animated avatar, but happy to put it behind a config flag instead if you would
rather keep the current behaviour as the default.

## Tests

Five cases added to `TestPixivArtist` — three on the helper (static, gif, `None`)
and two through `ParseBackground` with a synthetic ajax payload, so no new
test_data fixture is needed. `test_PixivModel`, `test_PixivModel_whitecube` and
`test_PixivHelper` run green together (53 tests).
